### PR TITLE
Get all CIDs for user (`INDEX /ipfs/cids`)

### DIFF
--- a/fission-web-api.cabal
+++ b/fission-web-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 77f1daa331c4adee79dceef81804ab607bbae0f7ad60e78919cd027d235c9c03
+-- hash: c91b69566832f2fe37691e7b9ea649fc7c660a3061fb31e6cd053c4e8758d4f9
 
 name:           fission-web-api
 version:        1.1.0
@@ -102,6 +102,7 @@ library
       Fission.Web.Heroku
       Fission.Web.Heroku.MIME
       Fission.Web.IPFS
+      Fission.Web.IPFS.CID
       Fission.Web.IPFS.Download
       Fission.Web.IPFS.Pin
       Fission.Web.IPFS.Upload
@@ -425,6 +426,7 @@ test-suite fission-test
       Fission.Web.Heroku
       Fission.Web.Heroku.MIME
       Fission.Web.IPFS
+      Fission.Web.IPFS.CID
       Fission.Web.IPFS.Download
       Fission.Web.IPFS.Pin
       Fission.Web.IPFS.Upload

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-api
-version: '1.1.0'
+version: '1.2.0'
 category: API
 author: Brooklyn Zelenka
 maintainer: hello@brooklynzelenka.com

--- a/src/Fission/IPFS/CID/Types.hs
+++ b/src/Fission/IPFS/CID/Types.hs
@@ -30,7 +30,7 @@ newtype CID = CID { unaddress :: Text }
   deriving newtype  ( IsString )
 
 instance ToJSON CID where
-  toJSON (CID cid) = toJSON cid
+  toJSON (CID cid) = toJSON . UTF8.stripN 1 $ cid
 
 instance FromJSON CID where
   parseJSON = withText "ContentAddress" (pure . CID)

--- a/src/Fission/Internal/Orphanage.hs
+++ b/src/Fission/Internal/Orphanage.hs
@@ -5,9 +5,10 @@
 
 module Fission.Internal.Orphanage () where
 
-import RIO
-import RIO.Orphans ()
-import qualified RIO.Partial as Partial
+import           RIO
+import           RIO.Orphans ()
+import qualified RIO.ByteString.Lazy as Lazy
+import qualified RIO.Partial         as Partial
 
 import Control.Lens
 
@@ -30,6 +31,7 @@ import Servant.Swagger.Internal
 
 import qualified Fission.Config        as Config
 import qualified Fission.Storage.Types as DB
+import qualified Fission.Internal.UTF8 as UTF8
 
 instance Enum    UUID
 instance SqlType UUID
@@ -70,6 +72,12 @@ instance HasLogFunc (LogFunc, b) where
 
 instance HasLogFunc (LogFunc, b, c) where
   logFuncL = _1
+
+instance MimeRender PlainText a => MimeRender PlainText [a] where
+  mimeRender proxy values = "["<> meat <>"]"
+    where
+      meat :: Lazy.ByteString
+      meat =  Lazy.intercalate "," $ (UTF8.stripNBS 1 . mimeRender proxy) <$> values
 
 instance HasSwagger api => HasSwagger (BasicAuth x r :> api) where
   toSwagger _ = toSwagger (Proxy :: Proxy api)

--- a/src/Fission/Internal/UTF8.hs
+++ b/src/Fission/Internal/UTF8.hs
@@ -2,6 +2,7 @@ module Fission.Internal.UTF8
   ( Textable (..)
   , showLazyBS
   , stripN
+  , stripNBS
   , stripNewline
   , textToLazyBS
   , textShow
@@ -31,6 +32,12 @@ stripNewline bs = fromMaybe bs $ Lazy.stripSuffix "\n" bs
 
 textShow :: Show a => a -> Text
 textShow = textDisplay . displayShow
+
+stripNBS :: Natural -> Lazy.ByteString -> Lazy.ByteString
+stripNBS n bs = Lazy.drop i $ Lazy.take ((Lazy.length bs) - i) bs
+  where
+    i :: Int64
+    i = fromIntegral n
 
 stripN :: Natural -> Text -> Text
 stripN n = Text.dropEnd i . Text.drop i

--- a/src/Fission/User/CID/Query.hs
+++ b/src/Fission/User/CID/Query.hs
@@ -28,7 +28,7 @@ byUser :: Row s UserCID -> ID User -> Col s Bool
 row `byUser` uID = row ! #_userFK .== literal uID
 
 byCID :: Row s UserCID -> Text -> Col s Bool
-row `byCID`  hash = row ! #_cid    .== text hash
+row `byCID`  hash = row ! #_cid .== text hash
 
 inCIDs :: Row s UserCID -> [Text] -> Col s Bool
 row `inCIDs` hashes = row ! #_cid `isIn` fmap text hashes

--- a/src/Fission/User/CID/Types.hs
+++ b/src/Fission/User/CID/Types.hs
@@ -8,7 +8,7 @@ import Database.Selda
 
 import Fission.User (User (..))
 
--- | A user account, most likely a developer
+-- | A relationship of 'CID' to a 'User'
 data UserCID = UserCID
   { _userCID    :: ID UserCID
   , _userFK     :: ID User

--- a/src/Fission/Web.hs
+++ b/src/Fission/Web.hs
@@ -7,8 +7,8 @@ module Fission.Web
   , server
   ) where
 
-import RIO
-import RIO.Process (HasProcessContext)
+import           RIO
+import           RIO.Process (HasProcessContext)
 import qualified RIO.Text as Text
 
 import Data.Has
@@ -21,6 +21,7 @@ import           Fission.User
 import           Fission.Web.Server
 import qualified Fission.IPFS.Types as IPFS
 import           Fission.File.Types ()
+import           Fission.Internal.Orphanage ()
 
 import qualified Fission.Web.Auth    as Auth
 import qualified Fission.Web.IPFS    as IPFS

--- a/src/Fission/Web/IPFS.hs
+++ b/src/Fission/Web/IPFS.hs
@@ -11,13 +11,16 @@ import Database.Selda
 import Servant
 
 import           Fission.IPFS.Types        as IPFS
+import           Fission.User
+
 import           Fission.Web.Server
+import qualified Fission.Web.IPFS.CID      as CID
 import qualified Fission.Web.IPFS.Upload   as Upload
 import qualified Fission.Web.IPFS.Download as Download
 import qualified Fission.Web.IPFS.Pin      as Pin
-import           Fission.User
 
-type API = Upload.API
+type API = "cids" :> CID.API
+      :<|> Upload.API
       :<|> Download.API
       :<|> Pin.API
 
@@ -28,6 +31,7 @@ server :: HasLogFunc        cfg
        => Has IPFS.Timeout  cfg
        => User
        -> RIOServer         cfg API
-server usr = Upload.add usr
+server usr = CID.allForUser usr
+        :<|> Upload.add usr
         :<|> Download.get
         :<|> Pin.server usr

--- a/src/Fission/Web/IPFS/CID.hs
+++ b/src/Fission/Web/IPFS/CID.hs
@@ -1,0 +1,29 @@
+module Fission.Web.IPFS.CID
+  ( API
+  , allForUser
+  ) where
+
+import RIO
+
+import Database.Selda
+import Servant
+
+import qualified Fission.IPFS.Types     as IPFS
+import           Fission.IPFS.CID.Types as IPFS.CID
+
+import           Fission.User           (User (..))
+import           Fission.User.CID.Query
+import qualified Fission.User.CID.Table as Table
+
+import           Fission.Web.Server
+
+type API = Get '[PlainText, JSON] [CID]
+
+allForUser :: MonadSelda (RIO cfg) => User -> RIOServer cfg API
+allForUser User { _userID } = do
+  hashes <- query do
+    uCIDs <- select Table.userCIDs
+    restrict $ uCIDs `byUser` _userID
+    return $ uCIDs ! #_cid
+
+  return $ IPFS.CID <$> hashes


### PR DESCRIPTION
# Problem

1. Users should be able to see how many files they're storing
2. Many applications will use this as a "dumb" repo and just ask for everything

# Solution

Add an `INDEX /ipfs/cids` endpoint, scoped to the requesting user