### PR TITLE
Public `GET /ipfs`

### DIFF
--- a/fission-web-api.cabal
+++ b/fission-web-api.cabal
@@ -4,10 +4,10 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c91b69566832f2fe37691e7b9ea649fc7c660a3061fb31e6cd053c4e8758d4f9
+-- hash: 0104af9e4fb636e3f7fd054d58ce044ec4c0d34bd833f047790c2e4c02c0f138
 
 name:           fission-web-api
-version:        1.1.0
+version:        1.2.0
 category:       API
 homepage:       https://github.com/fission-suite/web-api#readme
 bug-reports:    https://github.com/fission-suite/web-api/issues

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-api
-version: '1.2.0'
+version: '1.3.0'
 category: API
 author: Brooklyn Zelenka
 maintainer: hello@brooklynzelenka.com

--- a/src/Fission/Web/IPFS.hs
+++ b/src/Fission/Web/IPFS.hs
@@ -22,7 +22,8 @@ import qualified Fission.Web.IPFS.Upload   as Upload
 import qualified Fission.Web.IPFS.Download as Download
 import qualified Fission.Web.IPFS.Pin      as Pin
 
-type API = PublicAPI :<|> AuthedAPI
+type API = AuthedAPI
+      :<|> PublicAPI
 
 type AuthedAPI = BasicAuth "registered users" User
                  :> AuthedAPI'
@@ -38,10 +39,9 @@ server :: HasLogFunc        cfg
        => MonadSelda   (RIO cfg)
        => Has IPFS.BinPath  cfg
        => Has IPFS.Timeout  cfg
-       -- => User
        => RIOServer         cfg API
-server = Download.get
-        :<|> authed
+server = authed
+    :<|> Download.get
 
 authed :: HasLogFunc        cfg
        => HasProcessContext cfg

--- a/src/Fission/Web/IPFS.hs
+++ b/src/Fission/Web/IPFS.hs
@@ -1,5 +1,8 @@
 module Fission.Web.IPFS
   ( API
+  , AuthedAPI
+  , PublicAPI
+  , authed
   , server
   ) where
 
@@ -19,19 +22,33 @@ import qualified Fission.Web.IPFS.Upload   as Upload
 import qualified Fission.Web.IPFS.Download as Download
 import qualified Fission.Web.IPFS.Pin      as Pin
 
-type API = "cids" :> CID.API
-      :<|> Upload.API
-      :<|> Download.API
-      :<|> Pin.API
+type API = PublicAPI :<|> AuthedAPI
+
+type AuthedAPI = BasicAuth "registered users" User
+                 :> AuthedAPI'
+
+type AuthedAPI' = "cids" :> CID.API
+             :<|> Upload.API
+             :<|> Pin.API
+
+type PublicAPI = Download.API
 
 server :: HasLogFunc        cfg
        => HasProcessContext cfg
        => MonadSelda   (RIO cfg)
        => Has IPFS.BinPath  cfg
        => Has IPFS.Timeout  cfg
-       => User
-       -> RIOServer         cfg API
-server usr = CID.allForUser usr
+       -- => User
+       => RIOServer         cfg API
+server = Download.get
+        :<|> authed
+
+authed :: HasLogFunc        cfg
+       => HasProcessContext cfg
+       => MonadSelda   (RIO cfg)
+       => Has IPFS.BinPath  cfg
+       => Has IPFS.Timeout  cfg
+       => RIOServer         cfg AuthedAPI
+authed usr = CID.allForUser usr
         :<|> Upload.add usr
-        :<|> Download.get
         :<|> Pin.server usr

--- a/src/Fission/Web/Routes.hs
+++ b/src/Fission/Web/Routes.hs
@@ -10,18 +10,17 @@ import RIO
 
 import Servant
 
-import           Fission.User
 import qualified Fission.Web.IPFS   as IPFS
 import qualified Fission.Web.Ping   as Ping
 import qualified Fission.Web.Heroku as Heroku
 
-type API = IPFSRoute :<|> HerokuRoute :<|> PingRoute
+type API = IPFSRoute
+      :<|> HerokuRoute
+      :<|> PingRoute
 
 type PublicAPI = IPFSRoute
 
-type IPFSRoute = "ipfs"
-                 :> BasicAuth "registered users" User
-                 :> IPFS.API
+type IPFSRoute = "ipfs" :> IPFS.API
 
 type HerokuRoute = "heroku"
                    :> BasicAuth "heroku add-on api" ByteString


### PR DESCRIPTION
# Problem

restricting fetches seems a bridge too far. Totally possible to restrict to authed users with temporary tokens and whatnot, but it would be good to be compatible with gateway APIs &c

# Solution

Make the `GET /ipfs/*` endpoint not require auth