### PR TITLE
Normalized `stripN`

### DIFF
--- a/fission-web-api.cabal
+++ b/fission-web-api.cabal
@@ -4,10 +4,10 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0104af9e4fb636e3f7fd054d58ce044ec4c0d34bd833f047790c2e4c02c0f138
+-- hash: 73a0da2ab30fc1401ca4e120417a64bd929da70fcfc8735f0a61c16328c54ace
 
 name:           fission-web-api
-version:        1.2.0
+version:        1.3.0
 category:       API
 homepage:       https://github.com/fission-suite/web-api#readme
 bug-reports:    https://github.com/fission-suite/web-api/issues

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-api
-version: '1.3.0'
+version: '1.3.1'
 category: API
 author: Brooklyn Zelenka
 maintainer: hello@brooklynzelenka.com

--- a/src/Fission/IPFS/CID/Types.hs
+++ b/src/Fission/IPFS/CID/Types.hs
@@ -30,7 +30,10 @@ newtype CID = CID { unaddress :: Text }
   deriving newtype  ( IsString )
 
 instance ToJSON CID where
-  toJSON (CID cid) = toJSON . UTF8.stripN 1 $ cid
+  toJSON (CID cid) = toJSON $ normalize cid
+    where
+      normalize (Text.take 1 -> "\"") = UTF8.stripN 1 cid
+      normalize cid' = cid'
 
 instance FromJSON CID where
   parseJSON = withText "ContentAddress" (pure . CID)


### PR DESCRIPTION
# Problem

In some cases, the double-quote is not present on some CIDs (during cleanup). The usual method of just removing the first and last character then lops off critical characters from the hash.

Root cause unclear 🤷‍♀️

# Solution

Detect superflous double-quote, and remove.