### PR TITLE
Fix double quotes in DB issue

### DIFF
--- a/fission-web-api.cabal
+++ b/fission-web-api.cabal
@@ -4,10 +4,10 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 73a0da2ab30fc1401ca4e120417a64bd929da70fcfc8735f0a61c16328c54ace
+-- hash: 425836667f4accf080f1e9d94d27d3e848f5210810ac7d4951387b862ed736ff
 
 name:           fission-web-api
-version:        1.3.0
+version:        1.3.1
 category:       API
 homepage:       https://github.com/fission-suite/web-api#readme
 bug-reports:    https://github.com/fission-suite/web-api/issues

--- a/fission-web-api.cabal
+++ b/fission-web-api.cabal
@@ -4,10 +4,10 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 425836667f4accf080f1e9d94d27d3e848f5210810ac7d4951387b862ed736ff
+-- hash: 0db4b89c8028c41a9cb746581ebcea43c21b5bab8cfefd372a4027c9f23c5b6a
 
 name:           fission-web-api
-version:        1.3.1
+version:        1.3.2
 category:       API
 homepage:       https://github.com/fission-suite/web-api#readme
 bug-reports:    https://github.com/fission-suite/web-api/issues

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-api
-version: '1.3.1'
+version: '1.3.2'
 category: API
 author: Brooklyn Zelenka
 maintainer: hello@brooklynzelenka.com

--- a/src/Fission/IPFS/SparseTree.hs
+++ b/src/Fission/IPFS/SparseTree.hs
@@ -16,11 +16,8 @@ import Fission.IPFS.Path.Types
 import Fission.IPFS.SparseTree.Types
 
 linearize :: SparseTree -> Either Error.Linearization Path
-linearize = fmap (Path . wrap "\"") . go
+linearize = fmap Path . go
   where
-  wrap :: Text -> Text -> Text
-  wrap outside inside = outside <> inside <> outside
-
   go :: SparseTree -> Either Error.Linearization Text
   go = \case
     Stub      (Name name)    -> Right $ UTF8.textShow name

--- a/src/Fission/Storage/IPFS.hs
+++ b/src/Fission/Storage/IPFS.hs
@@ -75,7 +75,7 @@ addFile raw name =
           let
             sparseTree  = Directory [(Hash rootCID, fileWrapper)]
             fileWrapper = Directory [(fileName, Content fileCID)]
-            rootCID     = CID . UTF8.stripN 1 $ UTF8.textShow outer
+            rootCID     = CID $ UTF8.textShow outer
             fileCID     = CID . UTF8.stripN 1 $ UTF8.textShow inner
             fileName    = Key name
           in

--- a/src/Fission/Storage/IPFS.hs
+++ b/src/Fission/Storage/IPFS.hs
@@ -75,8 +75,8 @@ addFile raw name =
           let
             sparseTree  = Directory [(Hash rootCID, fileWrapper)]
             fileWrapper = Directory [(fileName, Content fileCID)]
-            rootCID     = CID $ UTF8.textShow outer
-            fileCID     = CID $ UTF8.textShow inner
+            rootCID     = CID . UTF8.stripN 1 $ UTF8.textShow outer
+            fileCID     = CID . UTF8.stripN 1 $ UTF8.textShow inner
             fileName    = Key name
           in
             Right sparseTree

--- a/src/Fission/Storage/IPFS.hs
+++ b/src/Fission/Storage/IPFS.hs
@@ -53,7 +53,7 @@ addRaw raw =
   IPFS.Proc.run ["add", "-q"] raw <&> \case
     (ExitSuccess, result, _) ->
       case CL.lines result of
-        [cid] -> Right . mkCID $ UTF8.textShow cid
+        [cid] -> Right . mkCID . UTF8.stripN 1 $ UTF8.textShow cid
         bad   -> Left . UnexpectedOutput $ UTF8.textShow bad
 
     (ExitFailure _, _, err) ->


### PR DESCRIPTION
# Problem

1. [X] #81 `DELETE` does not remove CID
2. [X] Inconsistent double quotes around CID shown to user

# Analysis

## `DELETE` does not remove CID

* An extra layer of double quotes were present in the output from IPFS's `stdout`
  * e.g. Via log: `["\"QmQWoEjbKZhj1qpPSKUv7LRepRWTvZfvCoKBJFU9CQGrWa\""]`
    * End user sees `"QmQWoEjbKZhj1qpPSKUv7LRepRWTvZfvCoKBJFU9CQGrWa"`
* This was also putting extra double quotes _in the DB_
* When we looked up the CID, we would request it as a regular string
* No matches, because the DB is full of CIDs wrapped in an extra layer of quotes

## Inconsistent double quotes around CID shown to user

The above double-quote issue was noticed earlier in development, and assumed to be a JSON encoding issue, and handled in the `ToJSON` typeclass instance.

# Solution

1 & 2. Strip the extra quotes when reading from IPFS's `stdout`