### PR TITLE
Remove `/ipfs` from provision host

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ curl -H "Authorization: Basic 012345generatedfrommanifest==" \
 #    "config"  : {
 #       "INTERPLANETARY_FISSION_USERNAME" : "c74bd95b8555275277d4",
 #       "INTERPLANETARY_FISSION_PASSWORD" : "GW0SHByPmY0.y+lg)x7De.PNmJvh1",
-#       "INTERPLANETARY_FISSION_URL"      : "localhost:1337/ipfs"
+#       "INTERPLANETARY_FISSION_URL"      : "localhost:1337"
 #    }
 # }
 ```

--- a/src/Fission/Platform/Heroku/Provision.hs
+++ b/src/Fission/Platform/Heroku/Provision.hs
@@ -135,7 +135,7 @@ instance ToSchema Provision where
         }
 
       cfgEx = Heroku.UserConfig
-        { _interplanetaryFissionUrl      = "https://hostless.dev/ipfs"
+        { _interplanetaryFissionUrl      = "https://hostless.dev"
         , _interplanetaryFissionUsername = "c74bd95b8555275277d4"
         , _interplanetaryFissionPassword = Secret "GW0SHByPmY0.y+lg)x7De.PNmJvh1"
         }

--- a/src/Fission/Web/Heroku.hs
+++ b/src/Fission/Web/Heroku.hs
@@ -48,7 +48,7 @@ create Request {_uuid, _region} =
 
     let
       userConfig = Heroku.UserConfig
-        { Heroku._interplanetaryFissionUrl      = url <> "/ipfs"
+        { Heroku._interplanetaryFissionUrl      = url
         , Heroku._interplanetaryFissionUsername = User.hashID userID
         , Heroku._interplanetaryFissionPassword = Secret secret
         }


### PR DESCRIPTION
# Problem

Heroku provision includes the `/ipfs` path. This makes it difficult to access other parts of the API.

# Solution

No longer append `/ipfs` in provision