### PR TITLE
Remove dollar signs from generated passwords

### DIFF
--- a/src/Fission/Random.hs
+++ b/src/Fission/Random.hs
@@ -33,7 +33,6 @@ urlSpecials =
   fmap (==)
     [ _asterisk
     , _comma
-    , _dollar
     , _exclam
     , _hyphen
     , _parenleft


### PR DESCRIPTION
# Problem
Dollar signs cause issues when setting passwords as env variables.

# Solution
Remove dollar signs in random password generation