### PR TITLE
add note about needing to install liblzma

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew service start ipfs
 # Enable sample Heroku config
 mv addon-manifest.json.example addon-manifest.json
 
-# If using linux, install liblzma-dev
+# If using Linux, install liblzma-dev
 # sudo apt install liblzma-dev
 
 # Dev Web Server

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ brew service start ipfs
 # Enable sample Heroku config
 mv addon-manifest.json.example addon-manifest.json
 
+# If using linux, install liblzma-dev
+# sudo apt install liblzma-dev
+
 # Dev Web Server
 export RIO_VERBOSE=true
 stack run fission-web


### PR DESCRIPTION
# Problem
Quick start instructions don't work on linux because `liblzma-dev` must be installed separately

# Solution
Add a note in Readme QuickStart instructions to `sudo apt install liblzma-dev` on linux