### PR TITLE
Turn on Clang backend optimzations

### DIFF
--- a/fission-web-api.cabal
+++ b/fission-web-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 28b4d9906e8d9b1cea63d98c514a515c3a5754d03525572cc03baf0449c84182
+-- hash: 89451e6d2830db89c858fe6dd69fc5289f28a8ddce9e3a0fa3cd9fec09096ad7
 
 name:           fission-web-api
 version:        1.8.0
@@ -15,14 +15,13 @@ author:         Brooklyn Zelenka,
                 Daniel Holmgren
 maintainer:     brooklyn@fission.codes,
                 daniel@fission.codes
-copyright:      © 2019 Brooklyn Zelenka
+copyright:      © 2019 Fission Internet Software Services for Open Networks Inc.
 license:        AGPL-3.0-or-later
 license-file:   LICENSE
-tested-with:    GHC==8.6.4
+tested-with:    GHC==8.6.5
 build-type:     Simple
 extra-source-files:
     README.md
-    CHANGELOG.md
 
 source-repository head
   type: git
@@ -223,7 +222,7 @@ executable fission-cli
   hs-source-dirs:
       fission-cli
   default-extensions: ApplicativeDo BangPatterns BinaryLiterals BlockArguments ConstraintKinds DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving KindSignatures LambdaCase LiberalTypeSynonyms MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings OverloadedLabels OverloadedLists PostfixOperators RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TupleSections TypeSynonymInstances TemplateHaskell TypeOperators ViewPatterns
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wpartial-fields -Wredundant-constraints -fhide-source-paths -threaded -rtsopts -flate-specialise -with-rtsopts=-N -with-rtsopts=-T -O2
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wpartial-fields -Wredundant-constraints -fhide-source-paths -threaded -flate-specialise -rtsopts -with-rtsopts=-N -with-rtsopts=-T -optc-ffast-math -optc-O3 -O2
   build-depends:
       aeson
     , aeson-casing
@@ -289,7 +288,7 @@ executable fission-web
   hs-source-dirs:
       fission-web
   default-extensions: ApplicativeDo BangPatterns BinaryLiterals BlockArguments ConstraintKinds DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving KindSignatures LambdaCase LiberalTypeSynonyms MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings OverloadedLabels OverloadedLists PostfixOperators RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TupleSections TypeSynonymInstances TemplateHaskell TypeOperators ViewPatterns
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wpartial-fields -Wredundant-constraints -fhide-source-paths -threaded -rtsopts -flate-specialise -with-rtsopts=-N -with-rtsopts=-T -O2
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wpartial-fields -Wredundant-constraints -fhide-source-paths -threaded -rtsopts -flate-specialise -with-rtsopts=-N -with-rtsopts=-T -optc-ffast-math -optc-O3 -O2
   build-depends:
       aeson
     , aeson-casing

--- a/package.yaml
+++ b/package.yaml
@@ -142,6 +142,8 @@ executables:
       - -flate-specialise
       - -with-rtsopts=-N
       - -with-rtsopts=-T
+      - -optc-ffast-math
+      - -optc-O3
       - -O2
 
   fission-cli:
@@ -152,10 +154,12 @@ executables:
       - wai-logger
     ghc-options:
       - -threaded
-      - -rtsopts
       - -flate-specialise
+      - -rtsopts
       - -with-rtsopts=-N
       - -with-rtsopts=-T
+      - -optc-ffast-math
+      - -optc-O3
       - -O2
 
 tests:

--- a/package.yaml
+++ b/package.yaml
@@ -138,8 +138,8 @@ executables:
       - wai-logger
     ghc-options:
       - -threaded
-      - -rtsopts
       - -flate-specialise
+      - -rtsopts
       - -with-rtsopts=-N
       - -with-rtsopts=-T
       - -optc-ffast-math


### PR DESCRIPTION
* Tried LLVM backend, decided against
  * Was a bit of a pain to set up
  * No discernible improvement
  * [This GHC GitLab Issue](https://gitlab.haskell.org/ghc/ghc/wikis/improved-llvm-backend#llvm-has-no-backwards-compatibility-guarantees) says mean things about it
* Turned on some Clang optimizations
  * `h2load` tests typically seeing around a 12% improvement
  * 12% is my minimum optimization threshold, so 👍

Closes #101 