### PR TITLE
default ipfs/cids to return JSON instead of PlainText

### DIFF
--- a/library/Fission/Web/IPFS/CID.hs
+++ b/library/Fission/Web/IPFS/CID.hs
@@ -17,7 +17,7 @@ import qualified Fission.User.CID.Table as Table
 
 import           Fission.Web.Server
 
-type API = Get '[PlainText, JSON] [CID]
+type API = Get '[JSON, PlainText] [CID]
 
 allForUser :: MonadSelda (RIO cfg) => User -> RIOServer cfg API
 allForUser User { _userID } = do


### PR DESCRIPTION
# Problem
/ipfs/cids route returns a plaintext string. Which forces the frontend to parse it into an array of CIDs
# Solution
default /ipfs/cids to return JSON, in this case an array of strings (CIDs)