### PR TITLE
add new line after error + success msgs

### DIFF
--- a/library/Fission/CLI/Display/Error.hs
+++ b/library/Fission/CLI/Display/Error.hs
@@ -13,7 +13,7 @@ put :: (MonadRIO cfg m, HasLogFunc cfg, Show err) => err -> Text -> m ()
 put err msg = do
   logDebug $ displayShow err
   liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red]
-  UTF8.putText $ Emoji.prohibited <> " " <> msg
+  UTF8.putText $ Emoji.prohibited <> " " <> msg <> "\n"
   liftIO $ ANSI.setSGR [ANSI.Reset]
 
 put' :: (MonadRIO cfg m, HasLogFunc cfg, Show err) => err -> m ()

--- a/library/Fission/CLI/Display/Success.hs
+++ b/library/Fission/CLI/Display/Success.hs
@@ -19,5 +19,5 @@ live hash = do
 putOk :: MonadIO m => Text -> m ()
 putOk msg = do
   liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Green]
-  UTF8.putText $ Emoji.whiteHeavyCheckMark <> " " <> msg
+  UTF8.putText $ Emoji.whiteHeavyCheckMark <> " " <> msg <> "\n"
   liftIO $ ANSI.setSGR [ANSI.Reset]


### PR DESCRIPTION
# Problem
No new line after error + success messages. Terminal gets messy and hard to read

# Solution
Added `\n` to error and success messages