### PR TITLE
Flow 🌊

### DIFF
--- a/fission-web-api.cabal
+++ b/fission-web-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cc8c6012f648eba2d65544e826ca27b053bc7ec9a49a3e5a25b5fc69bc0db024
+-- hash: b087f32db6030a0db3922527b9b062d816500d4d40a9ef66c384aff137308510
 
 name:           fission-web-api
 version:        1.10.0
@@ -88,6 +88,8 @@ library
       Fission.IPFS.Timeout.Types
       Fission.IPFS.Types
       Fission.IPFS.URL.Types
+      Fission.Log.Lens
+      Fission.Log.Types
       Fission.Monitor
       Fission.Monitor.Types
       Fission.Plan.Types
@@ -181,6 +183,7 @@ library
     , data-has
     , ekg-wai
     , envy
+    , flow
     , fsnotify
     , haskeline
     , http-client
@@ -246,6 +249,7 @@ executable fission-cli
     , ekg-wai
     , envy
     , fission-web-api
+    , flow
     , fsnotify
     , haskeline
     , http-client
@@ -311,6 +315,7 @@ executable fission-web
     , ekg-wai
     , envy
     , fission-web-api
+    , flow
     , fsnotify
     , haskeline
     , http-client
@@ -381,6 +386,7 @@ test-suite fission-doctest
     , doctest
     , ekg-wai
     , envy
+    , flow
     , fsnotify
     , haskeline
     , http-client
@@ -447,6 +453,7 @@ test-suite fission-lint
     , data-has
     , ekg-wai
     , envy
+    , flow
     , fsnotify
     , haskeline
     , hlint
@@ -554,6 +561,8 @@ test-suite fission-test
       Fission.IPFS.Timeout.Types
       Fission.IPFS.Types
       Fission.IPFS.URL.Types
+      Fission.Log.Lens
+      Fission.Log.Types
       Fission.Monitor
       Fission.Monitor.Types
       Fission.Plan.Types
@@ -649,6 +658,7 @@ test-suite fission-test
     , ekg-wai
     , envy
     , fission-web-api
+    , flow
     , fsnotify
     , haskeline
     , hspec
@@ -724,6 +734,7 @@ benchmark fission-benchmark
     , ekg-wai
     , envy
     , fission-web-api
+    , flow
     , fsnotify
     , haskeline
     , http-client

--- a/library/Fission/IPFS/Client.hs
+++ b/library/Fission/IPFS/Client.hs
@@ -10,6 +10,7 @@ module Fission.IPFS.Client
 import           RIO
 import qualified RIO.ByteString.Lazy as Lazy
 
+import Flow
 import Data.Has
 
 import qualified Network.HTTP.Client as HTTP
@@ -55,4 +56,11 @@ run :: MonadRIO         cfg m
 run query = do
   IPFS.URL url           <- Config.get
   manager :: HTTP.Manager <- Config.get
-  liftIO . runClientM query $ mkClientEnv manager url
+  -- liftIO . runClientM query $ mkClientEnv manager url
+
+  -- liftIO <. runClientM query <| mkClientEnv manager url
+
+  url
+    |> mkClientEnv manager
+    |> runClientM query
+    |> liftIO

--- a/library/Fission/IPFS/Process.hs
+++ b/library/Fission/IPFS/Process.hs
@@ -11,6 +11,7 @@ import           RIO
 import qualified RIO.ByteString.Lazy as Lazy
 import           RIO.Process
 
+import Flow
 import Data.Has
 
 import qualified Fission.Config as Config
@@ -84,6 +85,6 @@ ipfsProc processor inStream outStream opts = do
   IPFS.BinPath ipfs <- Config.get
   IPFS.Timeout secs <- Config.get
   let opts' = ("--timeout=" <> show secs <> "s") : opts
-  proc ipfs opts' $ processor
-                  . setStdin  inStream
-                  . setStdout outStream
+  proc ipfs opts' <| processor
+                  <. setStdin  inStream
+                  <. setStdout outStream

--- a/library/Fission/User/Mutate.hs
+++ b/library/Fission/User/Mutate.hs
@@ -1,5 +1,6 @@
 module Fission.User.Mutate (create) where
 
+import           Flow
 import           RIO
 
 import Database.Selda
@@ -37,5 +38,5 @@ create herokuUUID herokuRegion sekret = do
   uID <- insertWithPK Table.users
     [User def Regular True (Just hConfId) sekret <@ now]
 
-  logInfo $ "Inserted user " <> display uID
+  logInfo <| "Inserted user " <> display uID
   return uID

--- a/library/Fission/User/Security.hs
+++ b/library/Fission/User/Security.hs
@@ -1,6 +1,6 @@
 module Fission.User.Security (hashID) where
 
-import           RIO
+import           Flow
 import qualified RIO.Text as Text
 
 import Database.Selda (ID)
@@ -11,4 +11,4 @@ import Fission.User.Types
 -- | Create a 'SecretDigest' from the users ID
 --   Barely an obsfucating technique, but enough to hide DB ordering
 hashID :: ID User -> SecretDigest
-hashID = Text.take 20 . digest
+hashID = Text.take 20 <. digest

--- a/library/Fission/User/Types.hs
+++ b/library/Fission/User/Types.hs
@@ -1,5 +1,6 @@
 module Fission.User.Types (User (..))where
 
+import Flow
 import RIO
 
 import Control.Lens   ((?~))
@@ -12,7 +13,6 @@ import Fission.Security       (Digestable (..))
 import Fission.Security.Types (SecretDigest)
 import Fission.User.Role
 
--- import           Fission.Internal.Orphanage ()
 import qualified Fission.Internal.UTF8 as UTF8
 
 -- | A user account, most likely a developer
@@ -31,9 +31,15 @@ data User = User
              )
 
 instance Digestable (ID User) where
-  digest = digest . UTF8.textShow
+  digest = digest <. UTF8.textShow
 
 instance ToSchema (ID User) where
   declareNamedSchema _ =
-     return $ NamedSchema (Just "UserID")
-            $ mempty & type_ ?~ SwaggerInteger
+    pure <| NamedSchema (Just "UserID")
+         <| type_ ?~ SwaggerInteger
+         <| mempty
+
+    -- mempty
+    --   |> type_ ?~ SwaggerInteger
+    --   |> NamedSchema (Just "UserID")
+    --   |> pure

--- a/library/Fission/Web/Swagger/Docs.hs
+++ b/library/Fission/Web/Swagger/Docs.hs
@@ -6,9 +6,10 @@ module Fission.Web.Swagger.Docs
   , ping
   ) where
 
+import Flow
 import RIO
 
-import Control.Lens
+import Control.Lens    hiding ((|>))
 import Data.Swagger
 import Servant.Swagger
 
@@ -18,38 +19,38 @@ import qualified Fission.Web.Routes                       as Web
 
 app :: HasSwagger api => Proxy api -> Host -> Swagger
 app proxy appHost = toSwagger proxy
-                  & host               ?~ appHost
-                  & schemes            ?~ [Https, Http]
-                  & info . title       .~ "FISSION's IPFS API"
-                  & info . version     .~ "1.0.0"
-                  & info . description ?~ "Easily use IPFS from Web 2.0 applications"
-                  & info . contact     ?~ fissionContact
-                  & info . license     ?~ projectLicense
+                 |> host               ?~ appHost
+                 |> schemes            ?~ [Https, Http]
+                 |> info . title       .~ "FISSION's IPFS API"
+                 |> info . version     .~ "1.0.0"
+                 |> info . description ?~ "Easily use IPFS from Web 2.0 applications"
+                 |> info . contact     ?~ fissionContact
+                 |> info . license     ?~ projectLicense
   where
     fissionContact = mempty
-                   & name  ?~"FISSION Team"
-                   & url   ?~ URL "https://fission.codes"
-                   & email ?~ "support@fission.codes"
+                  |> name  ?~"FISSION Team"
+                  |> url   ?~ URL "https://fission.codes"
+                  |> email ?~ "support@fission.codes"
 
     projectLicense = "Apache 2.0"
-                   & url ?~ URL "http://www.apache.org/licenses/LICENSE-2.0"
+                  |> url ?~ URL "http://www.apache.org/licenses/LICENSE-2.0"
 
 auth :: Swagger -> Swagger
-auth = applyTagsFor ops  ["Authentication" & description ?~ "Auth actions & verification"]
+auth = applyTagsFor ops  ["Authentication" |> description ?~ "Auth actions & verification"]
   where
     ops = subOperations (Proxy :: Proxy Web.AuthRoute) (Proxy :: Proxy Web.API)
 
 heroku :: Swagger -> Swagger
-heroku = applyTagsFor ops  ["Heroku" & description ?~ "Interaction with the Heroku add-on API"]
+heroku = applyTagsFor ops  ["Heroku" |> description ?~ "Interaction with the Heroku add-on API"]
   where
     ops = subOperations (Proxy :: Proxy Web.HerokuRoute) (Proxy :: Proxy Web.API)
 
 ipfs :: Swagger -> Swagger
-ipfs = applyTagsFor ops ["IPFS" & description ?~ "The primary IPFS API"]
+ipfs = applyTagsFor ops ["IPFS" |> description ?~ "The primary IPFS API"]
   where
     ops = subOperations (Proxy :: Proxy Web.IPFSRoute) (Proxy :: Proxy Web.API)
 
 ping :: Swagger -> Swagger
-ping = applyTagsFor ops  ["Ping" & description ?~ "Check for liveness"]
+ping = applyTagsFor ops  ["Ping" |> description ?~ "Check for liveness"]
   where
     ops = subOperations (Proxy :: Proxy Web.PingRoute) (Proxy :: Proxy Web.API)

--- a/package.yaml
+++ b/package.yaml
@@ -84,6 +84,7 @@ dependencies:
   - data-has
   - ekg-wai
   - envy
+  - flow
   - fsnotify
   - haskeline
   - http-client


### PR DESCRIPTION
I've switch a few modules to use the [`Flow` library](https://www.stackage.org/haddock/lts-14.7/flow-1.0.18/Flow.html). I've used it before, and even wrote a [variant on it](http://hackage.haskell.org/package/flow-er) a few years ago. It's not _idiomatic_ Haskell, and the `|>` operator conflicts with something in `Control.Lens`, but it does provide a better visual metaphor than `$`, `&`, and `.` by pointing in the direction that the data flows.

Ben and Daniel will be familiar with the syntax from Elixir and Reason, respectively. The one difference versus _specifically Elixir_ is that it pipes to the **last** argument (not the first one).

Give it a look and tell me what you think. It's nonstandard, but it's really whatever makes the team happy, so I thought I'd whip it up.