### PR TITLE
Dynamic Peers in CLI setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -563,4 +563,5 @@ MigrationBackup/
 
 # End of https://www.gitignore.io/api/vim,emacs,sublimetext,visualstudio
 
-
+# Org mode users
+*.org

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ addon-manifest.json
 env.yaml
 domain-key.txt
 domain-crt.txt
+.env
 
 ### Haskell ###
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ addon-manifest.json
 env.yaml
 domain-key.txt
 domain-crt.txt
-.env
 
 ### Haskell ###
 dist

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ stack build
 cd .stack-work/dist/{YOUR_OS_FOLDER}/Cabal-2.4.0.1/build/fission-cli
 
 # Login to the fission service
-./fission-cli login
+stack run fission-cli login
 
 # LIVE FROM NEW YORK! ITS FISSION LIVE!
-./fission-cli up
+stack run fission-cli up
 ```
 
 # Development

--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ curl \
   http://localhost:1337/ipfs
 ```
 
+# Running the CLI
+```bash
+# Build the project
+stack build
+
+# Navigate to the folder containing our compiled assets
+cd .stack-work/dist/{YOUR_OS_FOLDER}/Cabal-2.4.0.1/build/fission-cli
+
+# Login to the fission service
+./fission-cli login
+
+# LIVE FROM NEW YORK! ITS FISSION LIVE!
+./fission-cli up
+```
+
 # Development
 
 There is a `Makefile` filled with helpful commands. The most used in development is `make watch`.

--- a/fission-cli/Main.hs
+++ b/fission-cli/Main.hs
@@ -28,10 +28,10 @@ main = do
   _ipfsTimeout <- withEnv "IPFS_TIMEOUT" (IPFS.Timeout 3600) (IPFS.Timeout . Partial.read)
 
   -- TODO: Grab from env.yaml file
-  isTLS <- getFlag "FISSION_TLS" .!~ True
+  isTLS <- getFlag "FISSION_TLS" .!~ False
   path  <- withEnv "FISSION_ROOT" "" id
-  host  <- withEnv "FISSION_HOST" "runfission.com" id
-  port  <- withEnv "FISSION_PORT" (if isTLS then 443 else 80) Partial.read
+  host  <- withEnv "FISSION_HOST" "127.0.0.1" id
+  port  <- withEnv "FISSION_PORT" 1337 Partial.read
   tOut  <- withEnv "FISSION_TIMEOUT" 1800000000 Partial.read
 
   let rawHTTPSettings = if isTLS

--- a/fission-cli/Main.hs
+++ b/fission-cli/Main.hs
@@ -27,11 +27,10 @@ main = do
   _ipfsPath    <- withEnv "IPFS_PATH" (IPFS.BinPath "/usr/local/bin/ipfs") IPFS.BinPath
   _ipfsTimeout <- withEnv "IPFS_TIMEOUT" (IPFS.Timeout 3600) (IPFS.Timeout . Partial.read)
 
-  -- TODO: Grab from env.yaml file
-  isTLS <- getFlag "FISSION_TLS" .!~ False
+  isTLS <- getFlag "FISSION_TLS" .!~ True
   path  <- withEnv "FISSION_ROOT" "" id
-  host  <- withEnv "FISSION_HOST" "127.0.0.1" id
-  port  <- withEnv "FISSION_PORT" 1337 Partial.read
+  host  <- withEnv "FISSION_HOST" "runfission.com" id
+  port  <- withEnv "FISSION_PORT" (if isTLS then 443 else 80) Partial.read
   tOut  <- withEnv "FISSION_TIMEOUT" 1800000000 Partial.read
 
   let rawHTTPSettings = if isTLS
@@ -42,7 +41,7 @@ main = do
     { managerResponseTimeout = responseTimeoutMicro tOut }
 
   let url         = BaseUrl (if isTLS then Https else Http) host port path
-      _fissionAPI = Client.Runner $ Client.request httpManager url
+      _fissionAPI = Client.Runner $ Client.mkRunner $ Client.request httpManager url
 
   withLogFunc logOptions \_logFunc -> runRIO CLI.Config {..} do
     logDebug $ "Requests will be made to " <> displayShow url

--- a/fission-cli/Main.hs
+++ b/fission-cli/Main.hs
@@ -27,6 +27,7 @@ main = do
   _ipfsPath    <- withEnv "IPFS_PATH" (IPFS.BinPath "/usr/local/bin/ipfs") IPFS.BinPath
   _ipfsTimeout <- withEnv "IPFS_TIMEOUT" (IPFS.Timeout 3600) (IPFS.Timeout . Partial.read)
 
+  -- TODO: Grab from env.yaml file
   isTLS <- getFlag "FISSION_TLS" .!~ True
   path  <- withEnv "FISSION_ROOT" "" id
   host  <- withEnv "FISSION_HOST" "runfission.com" id

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+<br/><img src="john.gif"/>

--- a/index.html
+++ b/index.html
@@ -1,1 +1,0 @@
-<br/><img src="john.gif"/>

--- a/library/Fission/CLI.hs
+++ b/library/Fission/CLI.hs
@@ -19,6 +19,7 @@ import qualified Fission.CLI.Command.Up       as Up
 import qualified Fission.CLI.Command.Down     as Down
 import qualified Fission.CLI.Command.Watch    as Watch
 import qualified Fission.CLI.Command.Whoami   as Whoami
+import           Fission.CLI.Config.Types
 
 -- | Top-level CLI description
 cli :: MonadRIO    cfg m
@@ -28,6 +29,7 @@ cli :: MonadRIO    cfg m
     => Has Client.Runner cfg
     => Has IPFS.BinPath  cfg
     => Has IPFS.Timeout  cfg
+    => Has UserConfig    cfg
     => m ()
 cli = do
   cfg <- ask

--- a/library/Fission/CLI/Auth.hs
+++ b/library/Fission/CLI/Auth.hs
@@ -21,7 +21,7 @@ import           Servant.Client
 import           Fission.Internal.Constraint
 import           Fission.Internal.Orphanage.BasicAuthData ()
 import qualified Fission.Internal.UTF8 as UTF8
-import           Fission.Config.Types
+import           Fission.CLI.Config.Types
 
 -- | Retrieve auth from the user's system
 get :: MonadIO m => m (Either YAML.ParseException UserConfig)

--- a/library/Fission/CLI/Auth.hs
+++ b/library/Fission/CLI/Auth.hs
@@ -21,13 +21,14 @@ import           Servant.Client
 import           Fission.Internal.Constraint
 import           Fission.Internal.Orphanage.BasicAuthData ()
 import qualified Fission.Internal.UTF8 as UTF8
+import           Fission.Config.Types
 
 -- | Retrieve auth from the user's system
-get :: MonadIO m => m (Either YAML.ParseException BasicAuthData)
+get :: MonadIO m => m (Either YAML.ParseException UserConfig)
 get = liftIO . YAML.decodeFileEither =<< cachePath
 
 -- | Write user's auth to a local on-system path
-write :: MonadUnliftIO m => BasicAuthData -> m ()
+write :: MonadUnliftIO m => UserConfig -> m ()
 write auth = do
   path <- cachePath
   writeBinaryFileDurable path $ YAML.encode auth
@@ -56,7 +57,7 @@ removeConfigFile = do
 
 withAuth :: MonadRIO   cfg m
          => HasLogFunc cfg
-         => (BasicAuthData -> m (Either ClientError a))
+         => (UserConfig -> m (Either ClientError a))
          -> m (Either SomeException a)
 withAuth action = get >>= \case
   Right auth ->

--- a/library/Fission/CLI/Auth.hs
+++ b/library/Fission/CLI/Auth.hs
@@ -57,11 +57,11 @@ removeConfigFile = do
 
 withAuth :: MonadRIO   cfg m
          => HasLogFunc cfg
-         => (UserConfig -> m (Either ClientError a))
+         => (BasicAuthData -> m (Either ClientError a))
          -> m (Either SomeException a)
 withAuth action = get >>= \case
   Right auth ->
-    action auth >>= pure . \case
+    action (toBasicAuth auth) >>= pure . \case
       Right result -> Right result
       Left err -> Left $ toException err
 

--- a/library/Fission/CLI/Command/Login.hs
+++ b/library/Fission/CLI/Command/Login.hs
@@ -70,10 +70,9 @@ login = do
 
       case authResult of
         Right peers -> do
-          let bytePeers = fmap (Lazy.toStrict . Peer.toByteString) peers
-              writeTo = UserConfig {username = username
+          let writeTo = UserConfig {username = username
                                     , password = (BS.pack password)
-                                    , peers = bytePeers}
+                                    , peers = peers}
 
           Auth.write writeTo >> CLI.Success.putOk "Logged in"
         Left  err -> CLI.Error.put err "Authorization failed"

--- a/library/Fission/CLI/Command/Login.hs
+++ b/library/Fission/CLI/Command/Login.hs
@@ -49,7 +49,10 @@ login = do
   logDebug "Starting login sequence"
   putStr "Username: "
   username <- getLine
-  runInputT defaultSettings $ getPassword (Just '•') "Password: " >>= \case
+
+  mayPassword <- liftIO $ runInputT defaultSettings $ getPassword (Just '•') "Password: "
+
+  case mayPassword of
     Nothing ->
       logError "Unable to read password"
 

--- a/library/Fission/CLI/Command/Login.hs
+++ b/library/Fission/CLI/Command/Login.hs
@@ -6,6 +6,7 @@ import           RIO.ByteString
 
 import qualified Data.ByteString.Char8 as BS
 import           Data.Has
+import           Data.List.NonEmpty as NonEmpty
 
 import           Options.Applicative.Simple (addCommand)
 import           Servant
@@ -14,7 +15,6 @@ import           System.Console.Haskeline
 import qualified Fission.Config as Config
 import           Fission.Internal.Constraint
 
-import           Fission.Web.User.Client  as User.Client
 import           Fission.Web.IPFS.Client  as IPFS.Client
 import qualified Fission.Web.Client.Types as Client
 
@@ -25,8 +25,6 @@ import qualified Fission.CLI.Display.Cursor  as Cursor
 import qualified Fission.CLI.Display.Success as CLI.Success
 import qualified Fission.CLI.Display.Error   as CLI.Error
 import qualified Fission.CLI.Display.Wait    as CLI.Wait
-import qualified Fission.IPFS.Peer.Types as Peer
-import qualified RIO.ByteString.Lazy as Lazy
 
 -- | The command to attach to the CLI tree
 command :: MonadIO m
@@ -64,15 +62,22 @@ login = do
       let auth = BasicAuthData username $ BS.pack password
 
       authResult <- Cursor.withHidden
-                 . CLI.Wait.waitFor "Verifying your credentials"
-                 . runner
-                 $ IPFS.Client.peers (IPFS.Client.request auth)
+                  . CLI.Wait.waitFor "Verifying your credentials"
+                  . runner
+                  $ IPFS.Client.peers (IPFS.Client.request auth)
 
       case authResult of
-        Right peers -> do
-          let writeTo = UserConfig {username = username
-                                    , password = (BS.pack password)
-                                    , peers = peers}
+        Left err ->
+          CLI.Error.put err "Authorization failed"
 
-          Auth.write writeTo >> CLI.Success.putOk "Logged in"
-        Left  err -> CLI.Error.put err "Authorization failed"
+        Right [] ->
+          CLI.Error.put_ "Unable to find peers"
+
+        Right peers -> do
+          let writeTo = UserConfig { username = username
+                                   , password = BS.pack password
+                                   , peers    = NonEmpty.fromList peers
+                                   }
+
+          Auth.write writeTo
+          CLI.Success.putOk "Logged in"

--- a/library/Fission/CLI/Command/Login.hs
+++ b/library/Fission/CLI/Command/Login.hs
@@ -24,6 +24,7 @@ import qualified Fission.CLI.Display.Cursor  as Cursor
 import qualified Fission.CLI.Display.Success as CLI.Success
 import qualified Fission.CLI.Display.Error   as CLI.Error
 import qualified Fission.CLI.Display.Wait    as CLI.Wait
+import           Fission.Config.Types
 
 -- | The command to attach to the CLI tree
 command :: MonadIO m
@@ -56,13 +57,18 @@ login = do
       logDebug "Attempting API verification"
       Client.Runner runner <- Config.get
       let auth = BasicAuthData username $ BS.pack password
-
+      let writeTo = UserConfig {
+        username=username,
+        password=(BS.pack password)
+      }
       authResult <- Cursor.withHidden
                  . liftIO
                  . CLI.Wait.waitFor "Verifying your credentials"
                  . runner
                  $ User.Client.verify auth
 
+
+
       case authResult of
-        Right _ok -> Auth.write auth >> CLI.Success.putOk "Logged in"
+        Right _ok -> Auth.write writeTo >> CLI.Success.putOk "Logged in"
         Left  err -> CLI.Error.put err "Authorization failed"

--- a/library/Fission/CLI/Command/Login.hs
+++ b/library/Fission/CLI/Command/Login.hs
@@ -15,6 +15,7 @@ import qualified Fission.Config as Config
 import           Fission.Internal.Constraint
 
 import           Fission.Web.User.Client  as User.Client
+import           Fission.Web.IPFS.Client  as IPFS.Client
 import qualified Fission.Web.Client.Types as Client
 
 import qualified Fission.CLI.Auth as Auth
@@ -63,7 +64,7 @@ login = do
                  . liftIO
                  . CLI.Wait.waitFor "Verifying your credentials"
                  . runner
-                 $ User.Client.verify auth
+                 $ IPFS.Client.peers auth
 
       case authResult of
         Right _ok -> Auth.write writeTo >> CLI.Success.putOk "Logged in"

--- a/library/Fission/CLI/Command/Login.hs
+++ b/library/Fission/CLI/Command/Login.hs
@@ -64,7 +64,7 @@ login = do
                  . liftIO
                  . CLI.Wait.waitFor "Verifying your credentials"
                  . runner
-                 $ IPFS.Client.peers auth
+                 $ IPFS.Client.peers (IPFS.Client.request auth)
 
       case authResult of
         Right _ok -> Auth.write writeTo >> CLI.Success.putOk "Logged in"

--- a/library/Fission/CLI/Command/Login.hs
+++ b/library/Fission/CLI/Command/Login.hs
@@ -49,7 +49,7 @@ login = do
   logDebug "Starting login sequence"
   putStr "Username: "
   username <- getLine
-  liftIO (runInputT defaultSettings $ getPassword (Just '•') "Password: ") >>= \case
+  runInputT defaultSettings $ getPassword (Just '•') "Password: " >>= \case
     Nothing ->
       logError "Unable to read password"
 
@@ -61,7 +61,6 @@ login = do
         writeTo = UserConfig { username = username, password = (BS.pack password) }
 
       authResult <- Cursor.withHidden
-                 . liftIO
                  . CLI.Wait.waitFor "Verifying your credentials"
                  . runner
                  $ IPFS.Client.peers (IPFS.Client.request auth)

--- a/library/Fission/CLI/Command/Login.hs
+++ b/library/Fission/CLI/Command/Login.hs
@@ -24,7 +24,6 @@ import qualified Fission.CLI.Display.Cursor  as Cursor
 import qualified Fission.CLI.Display.Success as CLI.Success
 import qualified Fission.CLI.Display.Error   as CLI.Error
 import qualified Fission.CLI.Display.Wait    as CLI.Wait
-import           Fission.Config.Types
 
 -- | The command to attach to the CLI tree
 command :: MonadIO m
@@ -56,18 +55,15 @@ login = do
     Just password -> do
       logDebug "Attempting API verification"
       Client.Runner runner <- Config.get
-      let auth = BasicAuthData username $ BS.pack password
-      let writeTo = UserConfig {
-        username=username,
-        password=(BS.pack password)
-      }
+      let
+        auth = BasicAuthData username $ BS.pack password
+        writeTo = UserConfig { username = username, password = (BS.pack password) }
+
       authResult <- Cursor.withHidden
                  . liftIO
                  . CLI.Wait.waitFor "Verifying your credentials"
                  . runner
                  $ User.Client.verify auth
-
-
 
       case authResult of
         Right _ok -> Auth.write writeTo >> CLI.Success.putOk "Logged in"

--- a/library/Fission/CLI/Command/Register.hs
+++ b/library/Fission/CLI/Command/Register.hs
@@ -2,9 +2,12 @@
 module Fission.CLI.Command.Register (command, register) where
 
 import           RIO
+<<<<<<< HEAD
 import           RIO.ByteString
 
 import qualified Data.ByteString.Char8 as BS
+=======
+>>>>>>> Save peers to fission yaml
 import           Data.Has
 import qualified Data.Text as T
 
@@ -26,6 +29,8 @@ import qualified Fission.CLI.Display.Cursor  as Cursor
 import qualified Fission.CLI.Display.Success as CLI.Success
 import qualified Fission.CLI.Display.Error   as CLI.Error
 import qualified Fission.CLI.Display.Wait    as CLI.Wait
+import qualified Fission.IPFS.Peer.Types as Peer
+import qualified RIO.ByteString.Lazy as Lazy
 
 -- | The command to attach to the CLI tree
 command :: MonadUnliftIO m
@@ -96,9 +101,16 @@ register' = do
           logDebug $ displayShow user
 
           let
+            -- Question: How could I do this automatically?
+            -- TODO: Move to helper
             username = encodeUtf8 $ user ^. Provision.username
             password = encodeUtf8 $ Security.unSecret $ user ^. Provision.password
-            auth     = UserConfig {username = username, password = password}
+            peers    = fmap (Lazy.toStrict . Peer.toByteString) (user ^. Provision.peers) -- Question: Theres got to be a simpler way to convert
+            auth     = UserConfig {
+              username = username,
+              password = password,
+              peers = peers
+            }
 
           Auth.write auth
           CLI.Success.putOk "Registered & logged in. Your credentials are in ~/.fission.yaml"

--- a/library/Fission/CLI/Command/Register.hs
+++ b/library/Fission/CLI/Command/Register.hs
@@ -2,12 +2,10 @@
 module Fission.CLI.Command.Register (command, register) where
 
 import           RIO
-<<<<<<< HEAD
 import           RIO.ByteString
 
 import qualified Data.ByteString.Char8 as BS
-=======
->>>>>>> Save peers to fission yaml
+
 import           Data.Has
 import qualified Data.Text as T
 
@@ -17,11 +15,13 @@ import           System.Console.Haskeline
 
 import qualified Fission.Config as Config
 import           Fission.Internal.Constraint
+import           Fission.Security as Security
 
 import qualified Fission.Web.User.Client  as User.Client
 import qualified Fission.Web.Client.Types as Client
 
 import qualified Fission.User.Registration.Types as User
+import           Fission.User.Provision.Types as Provision
 
 import qualified Fission.CLI.Auth as Auth
 import           Fission.CLI.Config.Types
@@ -97,7 +97,7 @@ register' = do
         Left  err ->
           CLI.Error.put err "Authorization failed"
 
-        Right _ok -> do
+        Right user -> do
           logDebug $ displayShow user
 
           let

--- a/library/Fission/CLI/Command/Register.hs
+++ b/library/Fission/CLI/Command/Register.hs
@@ -22,7 +22,6 @@ import qualified Fission.User.Registration.Types as User
 
 import qualified Fission.CLI.Auth as Auth
 import           Fission.CLI.Config.Types
-import Fission.Config.Types
 import qualified Fission.CLI.Display.Cursor  as Cursor
 import qualified Fission.CLI.Display.Success as CLI.Success
 import qualified Fission.CLI.Display.Error   as CLI.Error

--- a/library/Fission/CLI/Command/Register.hs
+++ b/library/Fission/CLI/Command/Register.hs
@@ -103,10 +103,10 @@ register' = do
           let
             -- Question: How could I do this automatically?
             -- TODO: Move to helper
-            username = encodeUtf8 $ user ^. Provision.username
-            password = encodeUtf8 $ Security.unSecret $ user ^. Provision.password
-            peers    = fmap (Lazy.toStrict . Peer.toByteString) (user ^. Provision.peers) -- Question: Theres got to be a simpler way to convert
-            auth     = UserConfig {
+            username   = encodeUtf8 $ user ^. Provision.username
+            password   = encodeUtf8 $ Security.unSecret $ user ^. Provision.password
+            peers      = user ^. Provision.peers -- Question: Theres got to be a simpler way to convert
+            auth       = UserConfig {
               username = username,
               password = password,
               peers = peers

--- a/library/Fission/CLI/Command/Register.hs
+++ b/library/Fission/CLI/Command/Register.hs
@@ -22,7 +22,7 @@ import qualified Fission.User.Registration.Types as User
 
 import qualified Fission.CLI.Auth as Auth
 import           Fission.CLI.Config.Types
-
+import Fission.Config.Types
 import qualified Fission.CLI.Display.Cursor  as Cursor
 import qualified Fission.CLI.Display.Success as CLI.Success
 import qualified Fission.CLI.Display.Error   as CLI.Error
@@ -94,5 +94,12 @@ register' = do
           CLI.Error.put err "Authorization failed"
 
         Right _ok -> do
-          Auth.write $ BasicAuthData username (BS.pack password)
+          logDebug $ displayShow user
+
+          let
+            username = encodeUtf8 $ user ^. Provision.username
+            password = encodeUtf8 $ Security.unSecret $ user ^. Provision.password
+            auth     = UserConfig {username = username, password = password}
+
+          Auth.write auth
           CLI.Success.putOk "Registered & logged in. Your credentials are in ~/.fission.yaml"

--- a/library/Fission/CLI/Command/Up.hs
+++ b/library/Fission/CLI/Command/Up.hs
@@ -21,6 +21,7 @@ import qualified Fission.CLI.Auth             as Auth
 import qualified Fission.CLI.Pin              as CLI.Pin
 import qualified Fission.CLI.DNS              as CLI.DNS
 import           Fission.CLI.Config.Types
+import qualified Fission.Config as Config
 
 -- | The command to attach to the CLI tree
 command :: MonadIO m
@@ -29,7 +30,8 @@ command :: MonadIO m
         => Has IPFS.BinPath  cfg
         => Has IPFS.Timeout  cfg
         => Has Client.Runner cfg
-        => cfg
+        => Has UserConfig  cfg
+         => cfg
         -> CommandM (m ())
 command cfg =
   addCommand
@@ -45,6 +47,7 @@ up :: MonadRIO          cfg m
    => HasProcessContext cfg
    => Has IPFS.Timeout  cfg
    => Has IPFS.BinPath  cfg
+   => Has UserConfig  cfg
    => Has Client.Runner cfg
    => Up.Options
    -> m ()
@@ -55,8 +58,8 @@ up Up.Options {..} = handleWith_ Error.put' do
   logDebug $ "Starting single IPFS add locally of " <> displayShow absPath
 
   unless dnsOnly do
-    config <- liftE Auth.get
-    void . liftE $ CLI.Pin.run cid (peers config) (toBasicAuth config)
+    userConfig <- Config.get
+    void . liftE $ CLI.Pin.run cid (peers userConfig) (toBasicAuth userConfig)
 
   liftE . Auth.withAuth $ CLI.DNS.update cid
 

--- a/library/Fission/CLI/Command/Up.hs
+++ b/library/Fission/CLI/Command/Up.hs
@@ -40,6 +40,7 @@ command cfg =
 
 -- | Sync the current working directory to the server over IPFS
 up :: MonadRIO          cfg m
+   => MonadUnliftIO         m
    => HasLogFunc        cfg
    => HasProcessContext cfg
    => Has IPFS.Timeout  cfg
@@ -54,7 +55,8 @@ up Up.Options {..} = handleWith_ Error.put' do
   logDebug $ "Starting single IPFS add locally of " <> displayShow absPath
 
   unless dnsOnly do
-    void . liftE . Auth.withAuth $ CLI.Pin.run cid
+    config <- liftE Auth.get
+    void . liftE $ CLI.Pin.run cid (peers config) (toBasicAuth config)
 
   liftE . Auth.withAuth $ CLI.DNS.update cid
 

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -24,6 +24,7 @@ import qualified Fission.Internal.UTF8 as UTF8
 import qualified Fission.Web.Client   as Client
 import qualified Fission.Storage.IPFS as IPFS
 import qualified Fission.Time         as Time
+import qualified Fission.Config as Config
 
 import           Fission.IPFS.CID.Types
 import qualified Fission.IPFS.Types as IPFS
@@ -43,6 +44,7 @@ command :: MonadIO m
         => HasLogFunc        cfg
         => Has Client.Runner cfg
         => HasProcessContext cfg
+        => Has UserConfig    cfg
         => Has IPFS.BinPath  cfg
         => Has IPFS.Timeout  cfg
         => cfg
@@ -60,6 +62,7 @@ watcher :: MonadRIO          cfg m
         => HasLogFunc        cfg
         => Has Client.Runner cfg
         => HasProcessContext cfg
+        => Has UserConfig    cfg
         => Has IPFS.BinPath  cfg
         => Has IPFS.Timeout  cfg
         => Watch.Options
@@ -88,6 +91,7 @@ handleTreeChanges :: HasLogFunc        cfg
                   => HasProcessContext cfg
                   => Has IPFS.BinPath  cfg
                   => Has IPFS.Timeout  cfg
+                  => Has UserConfig    cfg
                   => MVar UTCTime
                   -> MVar Text
                   -> WatchManager
@@ -122,13 +126,14 @@ pinAndUpdateDNS :: MonadRIO          cfg m
                 => HasProcessContext cfg
                 => Has IPFS.BinPath  cfg
                 => Has IPFS.Timeout  cfg
+                => Has UserConfig    cfg
                 => CID
                 -> m (Either SomeException AWS.DomainName)
 pinAndUpdateDNS cid = runExceptT do
-  config <- liftE Auth.get
-  let auth = toBasicAuth config
+  userConfig <- Config.get
+  let auth = toBasicAuth userConfig
 
-  _ <- liftE $ CLI.Pin.run cid (peers config) auth
+  _ <- liftE $ CLI.Pin.run cid (peers userConfig) auth
   liftE $ CLI.DNS.update cid auth
 
 parseOptions :: Parser Watch.Options

--- a/library/Fission/CLI/Command/Whoami.hs
+++ b/library/Fission/CLI/Command/Whoami.hs
@@ -40,6 +40,6 @@ whoami = do
       UTF8.putText "💻 Currently logged in as: "
 
       liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
-      putStr $ basicAuthUsername auth <> "\n"
+      putStr $ username auth <> "\n"
 
       liftIO $ ANSI.setSGR [ANSI.Reset]

--- a/library/Fission/CLI/Config/Types.hs
+++ b/library/Fission/CLI/Config/Types.hs
@@ -52,13 +52,12 @@ instance Has IPFS.Timeout Config where
   hasLens = ipfsTimeout
 
 
--- | TODO move to cli types (idea: DotFile UserDotFileConifg)
 -- | The User specific Fission CLI config
 data UserConfig = UserConfig
   { username :: ByteString
   , password :: ByteString
   -- , url      :: ByteString
-  -- , peers    :: [ByteString]
+  , peers    :: [ByteString]
   }
   deriving          ( Eq
                     , Show
@@ -66,15 +65,22 @@ data UserConfig = UserConfig
 
 
 instance ToJSON UserConfig where
-  toJSON (UserConfig username password) =
-    Object [ ("username", String $ decodeUtf8Lenient username)
-            , ("password", String $ decodeUtf8Lenient password)
-            ]
+  toJSON UserConfig {..} = object
+    [ "username"      .= username
+    , "password"  .= password
+    , "peers" .= peers
+    ]
+  -- toJSON (UserConfig username password peers) =
+  --   Object [ ("username", String $ decodeUtf8Lenient username)
+  --           , ("password", String $ decodeUtf8Lenient password)
+  --           , ("peers", map (String . decodeUtf8Lenient) peers)
+  --           ]
 
 instance FromJSON UserConfig where
   parseJSON = withObject "UserConfig" \obj ->
     UserConfig <$> obj .: "username"
                <*> obj .: "password"
+               <*> obj .: "peers"
 
 toBasicAuth :: UserConfig -> BasicAuthData
 toBasicAuth usrCfg = BasicAuthData (usrCfg & username) (usrCfg & password)

--- a/library/Fission/CLI/Config/Types.hs
+++ b/library/Fission/CLI/Config/Types.hs
@@ -57,7 +57,7 @@ data UserConfig = UserConfig
   { username :: ByteString
   , password :: ByteString
   -- , url      :: ByteString
-  , peers    :: [IPFS.Peer]
+  , peers    :: NonEmpty IPFS.Peer
   }
   deriving          ( Eq
                     , Show

--- a/library/Fission/CLI/Config/Types.hs
+++ b/library/Fission/CLI/Config/Types.hs
@@ -57,7 +57,7 @@ data UserConfig = UserConfig
   { username :: ByteString
   , password :: ByteString
   -- , url      :: ByteString
-  , peers    :: [ByteString]
+  , peers    :: [IPFS.Peer]
   }
   deriving          ( Eq
                     , Show

--- a/library/Fission/CLI/Display/Error.hs
+++ b/library/Fission/CLI/Display/Error.hs
@@ -1,20 +1,22 @@
 -- | File sync, IPFS-style
-module Fission.CLI.Display.Error (put, put') where
+module Fission.CLI.Display.Error
+  ( put
+  , put'
+  , put_
+  ) where
 
-import           RIO
+import RIO
 
 import qualified System.Console.ANSI as ANSI
 
 import           Fission.Internal.Constraint
-import qualified Fission.Internal.UTF8 as UTF8
+import qualified Fission.Internal.UTF8       as UTF8
 
 -- | Display a given error to the user and log an error to the debug log.
 put :: (MonadRIO cfg m, HasLogFunc cfg, Show err) => err -> Text -> m ()
 put err msg = do
   logDebug $ displayShow err
-  liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red]
-  UTF8.putText $ "🚫 " <> msg <> "\n"
-  liftIO $ ANSI.setSGR [ANSI.Reset]
+  put_ msg
 
 -- | Display a generic error message to the user and log an error to the debug log.
 put' :: (MonadRIO cfg m, HasLogFunc cfg, Show err) => err -> m ()
@@ -22,3 +24,10 @@ put' err = put err $ mconcat
   [ "Something went wrong. Please try again or file a bug report with "
   , "Fission support at https://github.com/fission-suite/web-api/issues/new"
   ]
+
+-- | Display a given error to the user
+put_ :: MonadIO m => Text -> m ()
+put_ msg = do
+  liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red]
+  UTF8.putText $ "🚫 " <> msg <> "\n"
+  liftIO $ ANSI.setSGR [ANSI.Reset]

--- a/library/Fission/CLI/Pin.hs
+++ b/library/Fission/CLI/Pin.hs
@@ -12,32 +12,33 @@ import Data.Has
 import Servant
 import Servant.Client
 
-import qualified Fission.Config as Config
+import qualified Fission.Config              as Config
 import           Fission.Internal.Constraint
 
-import           Fission.Internal.Exception as Exception
+import Fission.Internal.Exception as Exception
 
-import qualified Fission.IPFS.Peer    as IPFS.Peer
-import qualified Fission.IPFS.Types   as IPFS
 import           Fission.IPFS.CID.Types
+import qualified Fission.IPFS.Peer      as IPFS.Peer
+import qualified Fission.IPFS.Types     as IPFS
 
 import qualified Fission.Web.Client      as Client
 import qualified Fission.Web.IPFS.Client as Fission
 
+import           Fission.CLI.Config.Types
 import           Fission.CLI.Display.Error   as CLI.Error
 import qualified Fission.CLI.Display.Loader  as CLI
 import           Fission.CLI.Display.Success as CLI.Success
-import           Fission.CLI.Config.Types
-import           RIO.List (headMaybe)
+import           RIO.List                    (headMaybe)
 
 import Control.Monad.Except
 
 maybeToEither:: Maybe val -> err -> Either err val
 maybeToEither maybeA err = case maybeA of
   Just val -> Right val
-  Nothing -> Left err
+  Nothing  -> Left err
 
 run :: MonadRIO          cfg m
+    => MonadUnliftIO         m
     => HasLogFunc        cfg
     => HasProcessContext cfg
     => Has Client.Runner cfg
@@ -45,37 +46,104 @@ run :: MonadRIO          cfg m
     => Has IPFS.Timeout  cfg
     => CID
     -> UserConfig
-    -> m (Either ClientError CID)
+    -> m (Either SomeException CID)
 -- run cid@(CID hash) userConfig = Exception.handleWith_ CLI.Error.put' $ do
-run cid@(CID hash) userConfig = runExceptT do
-  maybePeer <- liftE $ headMaybe $ peers userConfig
-  peer  <- liftE $ maybeToEither maybePeer "ERROR"
-  result  <- liftE $ IPFS.Peer.connect peer
-  Client.Runner runner <- Config.get
-  hold <- liftIO (pin runner userConfig cid)
-  CLI.Success.live hash
-  return $ Right cid
+run cid@(CID hash) userConfig = do -- runExceptT do
+  -- Client.Runner runner <- Config.get
 
-  -- logDebug $ "Remote pinning " <> display hash
+  -- let
+  --   maybePeer = headMaybe $ peers userConfig
+
+  -- peer <- return $ maybeToEither maybePeer (toException "ERROR")
+
+  -- result  <- liftE $ IPFS.Peer.connect peer
+  -- hold <- liftE $ pin runner userConfig cid
+  -- CLI.Success.live hash
+  -- return $ Right cid
+
+  Client.Runner runner <- Config.get
+
+  logDebug $ "Remote pinning " <> display hash
 
   -- IPFS.Peer.connect IPFS.Peer.fission
 
-  -- let hold = headMaybe $ peers userConfig
+  let
+    mayPeer = headMaybe $ peers userConfig
 
-  -- case hold of
-  --   Just pr -> IPFS.Peer.connect pr
+  peer <- ExceptT $ return $ maybeToEither mayPeer (toException MyError)
+  return $ IPFS.Peer.connect peer
+  bar <- liftE $ pin runner userConfig cid
+  -- CLI.Success.live hash
+  -- return cid
 
-  -- Client.Runner runner <- Config.get
-  -- liftIO (pin runner userConfig cid) >>= \case
-  --   Right _ -> do
-  --     CLI.Success.live hash
-  --     return $ Right cid
+  -- case foo' of
+  --   Left err -> return $ Left err
+  --   Right pr -> do
+  --     IPFS.Peer.connect pr
 
-  --   Left err -> do
-  --     CLI.Error.put' err
-  --     return $ Left err
+  --     bar <- pin runner userConfig cid
 
-pin :: MonadUnliftIO m => (ClientM NoContent -> m a) -> UserConfig -> CID -> m a
+  --     case bar of
+  --       Right _ -> do
+  --         CLI.Success.live hash
+  --         return $ Right cid
+
+  --       Left err -> do
+  --         CLI.Error.put' err
+  --         return $ Left $ toException err
+
+pin :: MonadUnliftIO m => (ClientM NoContent -> m (Either ClientError NoContent)) -> UserConfig -> CID -> m (Either ClientError NoContent)
 pin runner userConfig cid = do
   let auth = toBasicAuth userConfig
   CLI.withLoader 50000 . runner $ Fission.pin (Fission.request auth) cid
+
+-- MonadIO
+
+-- liftIO :: IO a -> m a
+
+data MyErrrrrrrrror = MyError
+  deriving (Show, Exception)
+
+-- toException :: err -> SomeException
+
+{-
+   doTHing
+   `catch` \case
+     BadSender -> ...
+     Timeout -> ....
+
+-}
+
+-- data EmailErrs = BadSender | Timeout | NoBody
+-- data DBErrs = CantConnect | DuplicateKey
+
+-- data MailingLIstErrs
+--   = Email EmailErrs
+--   | DB DBErrs
+
+
+{-
+data AnalyticsErrs = ...
+-}
+
+  -- [1,2,3] >>= \x ->
+  --   [x + 1] >>= \y ->
+  --     [x * 10, y * 100] >>= \z ->
+  --       [z]
+
+  -- do
+  --   x <- [1,2,3]
+  --   y <- [x + 1] -- [2,3,4]
+  --   z <- [x * 10, y *100] -- [10, 20, 30, 200, 300, 400]
+  --   [z]
+
+  -- instance Monad Maybe where
+  --   (=<<) :: (a -> Maybe b) -> Maybe a -> Maybe b
+  --   (=<<) :: (a -> IO b) -> IO a -> IO b
+  --   (=<<) :: (a -> [b]) -> [a] -> [b]
+  --   return :: a -> m a
+
+  --   Nothing >>= f = Nothing
+  --   Just x >>= f = f x
+
+  --   return val = Just val

--- a/library/Fission/CLI/Pin.hs
+++ b/library/Fission/CLI/Pin.hs
@@ -33,7 +33,7 @@ run :: MonadRIO          cfg m
     => Has IPFS.BinPath  cfg
     => Has IPFS.Timeout  cfg
     => CID
-    -> BasicAuthData
+    -> Config.UserConfig
     -> m (Either ClientError CID)
 run cid@(CID hash) auth = do
   logDebug $ "Remote pinning " <> display hash
@@ -49,5 +49,7 @@ run cid@(CID hash) auth = do
       CLI.Error.put' err
       return $ Left err
 
-pin :: MonadUnliftIO m => (ClientM NoContent -> m a) -> BasicAuthData -> CID -> m a
-pin runner auth cid = CLI.withLoader 50000 . runner $ Fission.pin (Fission.request auth) cid
+pin :: MonadUnliftIO m => (ClientM NoContent -> m a) -> Config.UserConfig -> CID -> m a
+pin runner userConfig cid = do
+  let auth = Config.toBasicAuth userConfig
+  CLI.withLoader 50000 . runner $ Fission.pin (Fission.request auth) cid

--- a/library/Fission/CLI/Pin.hs
+++ b/library/Fission/CLI/Pin.hs
@@ -25,6 +25,7 @@ import qualified Fission.Web.IPFS.Client as Fission
 import           Fission.CLI.Display.Error   as CLI.Error
 import qualified Fission.CLI.Display.Loader  as CLI
 import           Fission.CLI.Display.Success as CLI.Success
+import           Fission.CLI.Config.Types
 
 run :: MonadRIO          cfg m
     => HasLogFunc        cfg
@@ -33,7 +34,7 @@ run :: MonadRIO          cfg m
     => Has IPFS.BinPath  cfg
     => Has IPFS.Timeout  cfg
     => CID
-    -> Config.UserConfig
+    -> UserConfig
     -> m (Either ClientError CID)
 run cid@(CID hash) auth = do
   logDebug $ "Remote pinning " <> display hash
@@ -49,7 +50,7 @@ run cid@(CID hash) auth = do
       CLI.Error.put' err
       return $ Left err
 
-pin :: MonadUnliftIO m => (ClientM NoContent -> m a) -> Config.UserConfig -> CID -> m a
+pin :: MonadUnliftIO m => (ClientM NoContent -> m a) -> UserConfig -> CID -> m a
 pin runner userConfig cid = do
-  let auth = Config.toBasicAuth userConfig
+  let auth = toBasicAuth userConfig
   CLI.withLoader 50000 . runner $ Fission.pin (Fission.request auth) cid

--- a/library/Fission/CLI/Pin.hs
+++ b/library/Fission/CLI/Pin.hs
@@ -15,6 +15,7 @@ import Servant.Client
 import qualified Fission.Config as Config
 import           Fission.Internal.Constraint
 
+import           Fission.Internal.Exception
 import qualified Fission.IPFS.Peer    as IPFS.Peer
 import qualified Fission.IPFS.Types   as IPFS
 import           Fission.IPFS.CID.Types
@@ -28,6 +29,12 @@ import           Fission.CLI.Display.Success as CLI.Success
 import           Fission.CLI.Config.Types
 import RIO.List (headMaybe)
 
+maybeToEither:: Maybe a -> b -> Either a b
+maybeToEither a err = case a of
+  Just b -> Right b
+  Nothing -> Left err
+
+
 run :: MonadRIO          cfg m
     => HasLogFunc        cfg
     => HasProcessContext cfg
@@ -37,24 +44,33 @@ run :: MonadRIO          cfg m
     => CID
     -> UserConfig
     -> m (Either ClientError CID)
-run cid@(CID hash) userConfig = do
-  logDebug $ "Remote pinning " <> display hash
+run cid@(CID hash) userConfig = handleWith_ CLI.Error.put' $ do
+  maybePeer <- headMaybe $ peers userConfig
+  peer  <- liftE $ maybeToEither maybePeer "ERROR"
+  result  <- liftE $ IPFS.Peer.connect peer
+  Client.Runner runner <- Config.get
+  hold <- liftIO (pin runner userConfig cid)
+  CLI.Success.live hash
+  return $ Right cid
+
+  -- logDebug $ "Remote pinning " <> display hash
+
   -- IPFS.Peer.connect IPFS.Peer.fission
 
-  let hold = headMaybe $ peers userConfig
+  -- let hold = headMaybe $ peers userConfig
 
-  case hold of
-    Just pr -> IPFS.Peer.connect pr
+  -- case hold of
+  --   Just pr -> IPFS.Peer.connect pr
 
-  Client.Runner runner <- Config.get
-  liftIO (pin runner userConfig cid) >>= \case
-    Right _ -> do
-      CLI.Success.live hash
-      return $ Right cid
+  -- Client.Runner runner <- Config.get
+  -- liftIO (pin runner userConfig cid) >>= \case
+  --   Right _ -> do
+  --     CLI.Success.live hash
+  --     return $ Right cid
 
-    Left err -> do
-      CLI.Error.put' err
-      return $ Left err
+  --   Left err -> do
+  --     CLI.Error.put' err
+  --     return $ Left err
 
 pin :: MonadUnliftIO m => (ClientM NoContent -> m a) -> UserConfig -> CID -> m a
 pin runner userConfig cid = do

--- a/library/Fission/Config/Types.hs
+++ b/library/Fission/Config/Types.hs
@@ -1,7 +1,6 @@
 -- | Configuration types
 module Fission.Config.Types
   ( Config (..)
-  , UserConfig (..)
   , processCtx
   , logFunc
   , ipfsPath
@@ -11,7 +10,6 @@ module Fission.Config.Types
   , dbPool
   , herokuID
   , herokuPassword
-  , toBasicAuth
   ) where
 
 import           RIO
@@ -23,7 +21,6 @@ import           Data.Has
 import           Data.Aeson
 import           Database.Selda.PostgreSQL
 import qualified Network.HTTP.Client as HTTP
-import           Servant
 import qualified Servant.Client as Client
 
 import           Fission.Web.Types
@@ -121,30 +118,3 @@ instance Has AWS.DomainName Config where
 
 instance Has Host Config where
   hasLens = host
-
--- | TODO move to cli types (idea: DotFile UserDotFileConifg)
--- | The User specific Fission CLI config
-data UserConfig = UserConfig
-  { username :: ByteString
-  , password :: ByteString
-  -- , url      :: ByteString
-  -- , peers    :: [ByteString]
-  }
-  deriving          ( Eq
-                    , Show
-                    )
-
-
-instance ToJSON UserConfig where
-  toJSON (UserConfig username password) =
-    Object [ ("username", String $ decodeUtf8Lenient username)
-            , ("password", String $ decodeUtf8Lenient password)
-            ]
-
-instance FromJSON UserConfig where
-  parseJSON = withObject "UserConfig" \obj ->
-    UserConfig <$> obj .: "username"
-               <*> obj .: "password"
-
-toBasicAuth :: UserConfig -> BasicAuthData
-toBasicAuth usrCfg = BasicAuthData (usrCfg & username) (usrCfg & password)

--- a/library/Fission/IPFS/Peer.hs
+++ b/library/Fission/IPFS/Peer.hs
@@ -76,7 +76,8 @@ isExternalIPv4 ip = maybe False not isReserved
     isReserved = do
       ipAddress  <- extractIPfromPeerAddress $ Text.unpack ip
       normalized <- IPv4.decode $ Text.pack ipAddress
-      return $ IPv4.reserved normalized
+      -- TODO: revert to reserved
+      return $ IPv4.private normalized
 
 
 -- | Filter a list of peers to include only the externally accessable addresses

--- a/library/Fission/IPFS/Peer/Types.hs
+++ b/library/Fission/IPFS/Peer/Types.hs
@@ -1,4 +1,4 @@
-module Fission.IPFS.Peer.Types (Peer (..)) where
+module Fission.IPFS.Peer.Types (Peer (..), toByteString) where
 
 import RIO
 
@@ -29,7 +29,10 @@ instance ToSchema Peer where
             & description ?~ "An IPFS peer address"
 
 instance MimeRender PlainText Peer where
-  mimeRender _ = UTF8.textToLazyBS . peer
+  mimeRender _ = toByteString
 
 instance MimeRender OctetStream Peer where
-  mimeRender _ = UTF8.textToLazyBS . peer
+  mimeRender _ = toByteString
+
+-- Question: is there a way the type checker could do this for me?
+toByteString = UTF8.textToLazyBS . peer

--- a/library/Fission/IPFS/Peer/Types.hs
+++ b/library/Fission/IPFS/Peer/Types.hs
@@ -34,5 +34,4 @@ instance MimeRender PlainText Peer where
 instance MimeRender OctetStream Peer where
   mimeRender _ = toByteString
 
--- Question: is there a way the type checker could do this for me?
 toByteString = UTF8.textToLazyBS . peer

--- a/library/Fission/Internal/Exception.hs
+++ b/library/Fission/Internal/Exception.hs
@@ -86,3 +86,11 @@ handleWith_ errHandler actions = handleWith errHandler (void actions)
 -- >   return $ a + b
 liftE :: (Functor m, Exception e) => m (Either e a) -> ExceptT SomeException m a
 liftE = ExceptT . fmap (BF.first toException)
+
+liftE' :: (Functor m, Exception e) => m (Either e a) -> ExceptT SomeException m a
+liftE' mErrOrOk = ExceptT $ mErrOrOk <&> \case
+    Right val -> Right val
+    Left err -> Left $ toException err
+  -- case x of
+  --   Right val -> ExceptT $ return val
+  --   Left err -> ExceptT $ Left $ toException err

--- a/library/Fission/Internal/Orphanage/ByteString/Lazy.hs
+++ b/library/Fission/Internal/Orphanage/ByteString/Lazy.hs
@@ -13,3 +13,6 @@ instance MimeRender PlainText Lazy.ByteString where
 
 instance FromJSON ByteString where
   parseJSON = withText "ByteString" (pure . encodeUtf8)
+
+instance ToJSON ByteString where
+  toJSON = String . decodeUtf8Lenient

--- a/library/Fission/Platform/Heroku/Provision.hs
+++ b/library/Fission/Platform/Heroku/Provision.hs
@@ -9,7 +9,6 @@ module Fission.Platform.Heroku.Provision
   , Provision (..)
   , id
   , config
-  , peers
   , message
   ) where
 
@@ -29,8 +28,6 @@ import qualified Fission.Platform.Heroku.Types      as Heroku
 import qualified Fission.User.Provision.Types       as User
 import           Fission.Security.Types
 import           Fission.User                       (User)
-import           Fission.IPFS.Types                 as IPFS
-import           Fission.IPFS.Peer (fission)
 
 data Request = Request
   { _callbackUrl :: Text          -- ^ The URL which should be used to retrieve updated information about the add-on and the app which owns it.
@@ -122,7 +119,6 @@ From Heroku
 data Provision = Provision
   { _id      :: ID User           -- ^ User ID
   , _config  :: User.Provision    -- ^ Heroku env var payload
-  , _peers   :: [IPFS.Peer]       -- ^ IPFS peer list
   , _message :: Text              -- ^ A helpful human-readable message
   } deriving ( Eq
              , Show
@@ -141,7 +137,6 @@ instance ToSchema Provision where
   declareNamedSchema _ = do
     uId    <- declareSchemaRef (Proxy :: Proxy (ID User))
     usrCfg <- declareSchemaRef (Proxy :: Proxy User.Provision)
-    ipfsPeers <- declareSchemaRef (Proxy :: Proxy [IPFS.Peer])
     txt    <- declareSchemaRef (Proxy :: Proxy Text)
     return $ NamedSchema (Just "User Provision Response") $ mempty
            & type_      ?~ SwaggerObject
@@ -149,7 +144,6 @@ instance ToSchema Provision where
                [ ("id",      uId)
                , ("config",  usrCfg)
                , ("message", txt)
-               , ("peers", ipfsPeers)
                ]
            & required    .~ ["id" , "config"]
            & example     ?~ toJSON provisionEx
@@ -158,7 +152,6 @@ instance ToSchema Provision where
       provisionEx = Provision
         { _id      = toId 4213
         , _config  = cfgEx
-        , _peers  = [fission]
         , _message = "Provisioned successfully"
         }
 

--- a/library/Fission/Platform/Heroku/Provision.hs
+++ b/library/Fission/Platform/Heroku/Provision.hs
@@ -23,6 +23,7 @@ import Data.UUID as UUID
 import Data.Swagger hiding (name)
 import Database.Selda
 
+import qualified Fission.IPFS.Peer                  as IPFS.Peer
 import qualified Fission.Plan.Types                 as Plan
 import qualified Fission.Platform.Heroku.Types      as Heroku
 import qualified Fission.User.Provision.Types       as User
@@ -159,4 +160,5 @@ instance ToSchema Provision where
         { _url      = Client.BaseUrl Client.Https "runfission.com" 443 ""
         , _username = "c74bd95b8555275277d4"
         , _password = Secret "GW0SHByPmY0.y+lg)x7De.PNmJvh1"
+        , _peers    = [IPFS.Peer.fission]
         }

--- a/library/Fission/User/Provision/Types.hs
+++ b/library/Fission/User/Provision/Types.hs
@@ -22,7 +22,7 @@ data Provision = Provision
   { _url      :: Client.BaseUrl
   , _username :: Text
   , _password :: Secret
-  , _peers   :: [IPFS.Peer]
+  , _peers    :: [IPFS.Peer]
   } deriving ( Eq
              , Show
              , Generic

--- a/library/Fission/User/Provision/Types.hs
+++ b/library/Fission/User/Provision/Types.hs
@@ -3,6 +3,7 @@ module Fission.User.Provision.Types
   , url
   , password
   , username
+  , peers
   ) where
 
 import RIO
@@ -15,11 +16,13 @@ import qualified Servant.Client as Client
 import Fission.Security
 import Fission.Security.Types
 import Fission.Internal.Orphanage.BaseUrl ()
+import Fission.IPFS.Types as IPFS
 
 data Provision = Provision
   { _url      :: Client.BaseUrl
   , _username :: Text
   , _password :: Secret
+  , _peers   :: [IPFS.Peer]
   } deriving ( Eq
              , Show
              , Generic
@@ -32,6 +35,7 @@ instance FromJSON Provision where
     _url      <- obj .: "INTERPLANETARY_FISSION_URL"
     _username <- obj .: "INTERPLANETARY_FISSION_USERNAME"
     _password <- obj .: "INTERPLANETARY_FISSION_PASSWORD"
+    _peers <- obj .: "INTERPLANETARY_FISSION_PEERS"
     return Provision {..}
 
 instance ToJSON Provision where
@@ -39,6 +43,7 @@ instance ToJSON Provision where
     [ "INTERPLANETARY_FISSION_URL"      .= _url
     , "INTERPLANETARY_FISSION_USERNAME" .= _username
     , "INTERPLANETARY_FISSION_PASSWORD" .= _password
+    , "INTERPLANETARY_FISSION_PEERS" .= _peers
     ]
 
 instance ToSchema Provision where
@@ -46,6 +51,7 @@ instance ToSchema Provision where
     url'      <- declareSchemaRef (Proxy :: Proxy Client.BaseUrl)
     username' <- declareSchemaRef (Proxy :: Proxy Text)
     password' <- declareSchemaRef (Proxy :: Proxy Secret)
+    ipfsPeers <- declareSchemaRef (Proxy :: Proxy [IPFS.Peer])
 
     return $ NamedSchema (Just "UserConfig") $ mempty
       & type_      ?~ SwaggerObject
@@ -53,6 +59,7 @@ instance ToSchema Provision where
           [ ("INTERPLANETARY_FISSION_URL",      url')
           , ("INTERPLANETARY_FISSION_USERNAME", username')
           , ("INTERPLANETARY_FISSION_PASSWORD", password')
+          , ("INTERPLANETARY_FISSION_PEERS", ipfsPeers)
           ]
       & required .~
           [ "INTERPLANETARY_FISSION_URL"
@@ -65,4 +72,5 @@ instance ToSchema Provision where
           { _url      = Client.BaseUrl Client.Https "runfission.com" 443 ""
           , _username = "c74bd95b8555275277d4"
           , _password = Secret "GW0SHByPmY0.y+lg)x7De.PNmJvh1"
+          , _peers = [IPFS.Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"]
           }

--- a/library/Fission/Web/Client/Types.hs
+++ b/library/Fission/Web/Client/Types.hs
@@ -1,4 +1,4 @@
-module Fission.Web.Client.Types (Runner (..)) where
+module Fission.Web.Client.Types (Runner (..), mkRunner) where
 
 import RIO
 
@@ -6,3 +6,6 @@ import Servant.Client
 
 newtype Runner = Runner
   { getRunner :: forall m a. MonadIO m => ClientM a -> m (Either ClientError a) }
+
+mkRunner :: MonadIO m => (a -> IO b) -> (a -> m b)
+mkRunner = fmap liftIO

--- a/library/Fission/Web/Client/Types.hs
+++ b/library/Fission/Web/Client/Types.hs
@@ -5,4 +5,4 @@ import RIO
 import Servant.Client
 
 newtype Runner = Runner
-  { getRunner :: forall a. ClientM a -> IO (Either ClientError a) }
+  { getRunner :: forall m a. MonadIO m => ClientM a -> m (Either ClientError a) }

--- a/library/Fission/Web/Heroku.hs
+++ b/library/Fission/Web/Heroku.hs
@@ -79,11 +79,11 @@ provision Request {_uuid, _region} = do
                      logError $ displayShow err
                      return []
 
-  username     <- liftIO $ User.genID 
+  username     <- liftIO $ User.genID
   secret       <- liftIO $ Random.text 200
   User.createWithHeroku _uuid _region username secret >>= \case
     Left err -> Web.Err.throw err
-    Right userID -> do 
+    Right userID -> do
       logInfo $ mconcat
         [ "Provisioned UUID: "
         , displayShow _uuid
@@ -96,12 +96,12 @@ provision Request {_uuid, _region} = do
           { _url      = url
           , _username = User.hashID userID
           , _password = Secret secret
+          , _peers    = ipfsPeers
           }
 
       return Provision
         { _id      = userID
         , _config  = userConfig
-        , _peers   = ipfsPeers
         , _message = "Successfully provisioned Interplanetary Fission!"
         }
 

--- a/library/Fission/Web/IPFS.hs
+++ b/library/Fission/Web/IPFS.hs
@@ -34,14 +34,12 @@ type API = AuthedAPI
 
 type Auth = BasicAuth "registered users" User
 
-type AuthedAPI = Auth :> UnauthedAPI
-
--- Question : wait... is this just a poorly named variable.... none of these are intended to be accessed with out basic auth?
-type UnauthedAPI = "cids" :> CID.API
-              :<|> Upload.API
-              :<|> Pin.API
-              :<|> "dag" :> DAG.API
-              :<|>  "peers" :> Peer.API
+type AuthedAPI = Auth :> (
+  "cids" :> CID.API
+  :<|> Upload.API
+  :<|> Pin.API
+  :<|> "dag" :> DAG.API
+  :<|>  "peers" :> Peer.API)
 
 type PublicAPI = Download.API
 

--- a/library/Fission/Web/IPFS.hs
+++ b/library/Fission/Web/IPFS.hs
@@ -3,7 +3,6 @@ module Fission.Web.IPFS
   , Auth
   , AuthedAPI
   , PublicAPI
-  , UnauthedAPI
   , authed
   , public
   , server

--- a/library/Fission/Web/IPFS.hs
+++ b/library/Fission/Web/IPFS.hs
@@ -36,13 +36,14 @@ type Auth = BasicAuth "registered users" User
 
 type AuthedAPI = Auth :> UnauthedAPI
 
+-- Question : wait... is this just a poorly named variable.... none of these are intended to be accessed with out basic auth?
 type UnauthedAPI = "cids" :> CID.API
               :<|> Upload.API
               :<|> Pin.API
               :<|> "dag" :> DAG.API
+              :<|>  "peers" :> Peer.API
 
-type PublicAPI = "peers" :> Peer.API
-            :<|> Download.API
+type PublicAPI = Download.API
 
 server :: HasLogFunc        cfg
        => HasProcessContext cfg
@@ -66,11 +67,11 @@ authed usr = CID.allForUser usr
         :<|> Upload.add usr
         :<|> Pin.server usr
         :<|> DAG.put usr
+        :<|> Peer.get
 
 public :: HasLogFunc        cfg
        => HasProcessContext cfg
        => Has IPFS.BinPath  cfg
        => Has IPFS.Timeout  cfg
        => RIOServer         cfg PublicAPI
-public = Peer.get
-    :<|> Download.get
+public = Download.get

--- a/library/Fission/Web/IPFS/Client.hs
+++ b/library/Fission/Web/IPFS/Client.hs
@@ -21,6 +21,7 @@ import qualified Fission.Web.IPFS.CID           as CID
 import qualified Fission.Web.IPFS.Upload.Simple as Upload.Simple
 import qualified Fission.Web.IPFS.Pin           as Pin
 import qualified Fission.Web.IPFS.DAG           as DAG
+import qualified Fission.Web.IPFS.Peer          as Peer
 import           Fission.IPFS.Peer.Types
 
 type API = IPFSPrefix :> IPFS.Auth :> SimpleAPI
@@ -29,6 +30,7 @@ type SimpleAPI = "cids" :> CID.API
             :<|> Upload.Simple.API
             :<|> Pin.API
             :<|> "dag" :> DAG.API
+            :<|>  "peers" :> Peer.API
 
 data Request = Request
   { dagput :: File.Serialized -> ClientM CID
@@ -44,4 +46,4 @@ data Request = Request
 request :: BasicAuthData -> Request
 request ba = Request {..}
   where
-    cids :<|> peers :<|> upload :<|> (pin :<|> unpin) :<|> dagput = Client.withAuth ba (Proxy :: Proxy API)
+    cids :<|> upload :<|> (pin :<|> unpin) :<|> dagput :<|> peers = Client.withAuth ba (Proxy :: Proxy API)

--- a/library/Fission/Web/IPFS/Client.hs
+++ b/library/Fission/Web/IPFS/Client.hs
@@ -21,6 +21,7 @@ import qualified Fission.Web.IPFS.CID           as CID
 import qualified Fission.Web.IPFS.Upload.Simple as Upload.Simple
 import qualified Fission.Web.IPFS.Pin           as Pin
 import qualified Fission.Web.IPFS.DAG           as DAG
+import           Fission.IPFS.Peer.Types
 
 type API = IPFSPrefix :> IPFS.Auth :> SimpleAPI
 
@@ -35,10 +36,12 @@ data Request = Request
   , pin    :: CID             -> ClientM NoContent
   , upload :: File.Serialized -> ClientM CID
   , cids   :: ClientM [CID]
+  -- FINISH OFF NOTE: I couldn't figure out how to make an auth request TO peers. IT may involve how were doing type coersion?
+  , peers  :: ClientM [Peer]
   }
 
 -- | Generate authenticate client functions
 request :: BasicAuthData -> Request
 request ba = Request {..}
   where
-    cids :<|> upload :<|> (pin :<|> unpin) :<|> dagput = Client.withAuth ba (Proxy :: Proxy API)
+    cids :<|> peers :<|> upload :<|> (pin :<|> unpin) :<|> dagput = Client.withAuth ba (Proxy :: Proxy API)

--- a/library/Fission/Web/User.hs
+++ b/library/Fission/Web/User.hs
@@ -5,6 +5,7 @@ module Fission.Web.User
   ) where
 
 import RIO
+import           RIO.Process (HasProcessContext)
 
 import Data.Has
 import Database.Selda
@@ -16,6 +17,7 @@ import qualified Fission.Web.User.Create as Create
 import qualified Fission.Web.User.Verify as Verify
 import qualified Fission.Web.Auth.Types  as Auth
 import qualified Fission.Web.Types       as Web
+import           Fission.IPFS.Types      as IPFS
 
 import           Network.AWS.Auth  as AWS
 import qualified Fission.AWS.Types as AWS
@@ -30,6 +32,9 @@ type VerifyRoute = "verify"
 server :: HasLogFunc        cfg
        => MonadSelda   (RIO cfg)
        => Has Web.Host      cfg
+       => HasProcessContext cfg
+       => Has IPFS.BinPath cfg
+       => Has IPFS.Timeout cfg
        => Has AWS.DomainName    cfg
        => Has AWS.AccessKey  cfg
        => Has AWS.SecretKey  cfg


### PR DESCRIPTION

**Summary**

<!-- Summary of the PR -->

This PR implements the following **features**

* [x] Retrieving peer data on register
* [ ] Retrieving peer data on login
* [ ] Retrieving peer data on swarm connect failure

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

This is meant to
* keep our peer ip address from being hardcoded in the case of address changes
* allow for multiple peers
* allow for retries on failure


**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on Circle CI. -->

**Code formatting**

<!-- Make sure it passes ESLint. -->

**Closing issues**

closes #116 

