### PR TITLE
Generalize several functions to MonadIO and MonadUnliftIO

### DIFF
--- a/library/Fission/CLI/Display/Cursor.hs
+++ b/library/Fission/CLI/Display/Cursor.hs
@@ -6,5 +6,11 @@ import RIO
 import qualified System.Console.ANSI as ANSI
 
 -- | Perform console actions without a cursor visible
-withHidden :: MonadUnliftIO m => m c -> m c
-withHidden = bracket (liftIO ANSI.hideCursor) (const $ liftIO ANSI.showCursor) . const
+withHidden :: MonadUnliftIO m => m a -> m a
+withHidden action = bracket acquire release \_ -> action
+  where
+    acquire :: MonadIO m => m ()
+    acquire = liftIO ANSI.hideCursor
+
+    release :: MonadIO m => ignored -> m ()
+    release _ = liftIO ANSI.showCursor

--- a/library/Fission/CLI/Display/Wait.hs
+++ b/library/Fission/CLI/Display/Wait.hs
@@ -8,12 +8,12 @@ import qualified System.Console.ANSI as ANSI
 
 import Fission.CLI.Display.Loader
 
-waitFor :: ByteString -> IO a -> IO a
+waitFor :: MonadUnliftIO m => ByteString -> m a -> m a
 waitFor msg action = do
-  ANSI.cursorForward 3
-  ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Yellow]
+  liftIO $ ANSI.cursorForward 3
+  liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Yellow]
   putStr msg
-  ANSI.setCursorColumn 0
+  liftIO $ ANSI.setCursorColumn 0
   result <- withLoader 5000 action
-  ANSI.setSGR [ANSI.Reset]
+  liftIO $ ANSI.setSGR [ANSI.Reset]
   return result

--- a/library/Fission/CLI/Pin.hs
+++ b/library/Fission/CLI/Pin.hs
@@ -40,7 +40,7 @@ run cid@(CID hash) auth = do
   IPFS.Peer.connect IPFS.Peer.fission
 
   Client.Runner runner <- Config.get
-  pin runner auth cid >>= \case
+  liftIO (pin runner auth cid) >>= \case
     Right _ -> do
       CLI.Success.live hash
       return $ Right cid
@@ -49,8 +49,5 @@ run cid@(CID hash) auth = do
       CLI.Error.put' err
       return $ Left err
 
-pin :: MonadIO m => (ClientM NoContent -> IO a) -> BasicAuthData -> CID -> m a
-pin runner auth cid =
-  liftIO . CLI.withLoader 50000
-         . runner
-         $ Fission.pin (Fission.request auth) cid
+pin :: MonadUnliftIO m => (ClientM NoContent -> m a) -> BasicAuthData -> CID -> m a
+pin runner auth cid = CLI.withLoader 50000 . runner $ Fission.pin (Fission.request auth) cid

--- a/library/Fission/Web/Auth/Types.hs
+++ b/library/Fission/Web/Auth/Types.hs
@@ -1,5 +1,8 @@
 -- | Authorization types; primarily more semantic aliases
-module Fission.Web.Auth.Types where
+module Fission.Web.Auth.Types
+  ( ExistingUser
+  , HerokuAddOnAPI
+  ) where
 
 import RIO
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-api
-version: '1.13.0'
+version: '1.13.1'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
This came up in #139. There's a LOT of `liftIO` happening in there, and it gave a confusing error about `MonadReader cfg IO`. This will squash that and tighten up the code in a few places 😃 