### PR TITLE
Adjust AWS json to camelCase

### DIFF
--- a/example-config/env.yaml.example
+++ b/example-config/env.yaml.example
@@ -10,14 +10,14 @@ ipfs:
   timeout: 3600
 
 storage:
-  stripeCount: 4
-  connsPerStripe: 50
-  connTTL: 10
+  stripe_count: 4
+  conns_per_stripe: 50
+  conn_ttl: 10
   postgresql:
     host: localhost
     database: web_api
 aws:
   # access_key:
-  # secret_key: 
-  # zone_id: 
-  # domain_name: 
+  # secret_key:
+  # zone_id:
+  # domain_name:

--- a/fission-web/Main.hs
+++ b/fission-web/Main.hs
@@ -35,7 +35,7 @@ import qualified Fission.AWS.Environment.Types as AWS
 main :: IO ()
 main = do
   Just  manifest <- JSON.decodeFileStrict "./addon-manifest.json"
-  Right env      <- YAML.decodeFileEither "./env.yaml"
+  env            <- YAML.decodeFileThrow  "./env.yaml"
 
   let
     Storage.Environment {..} = env ^. storage

--- a/library/Fission/AWS/Environment/Types.hs
+++ b/library/Fission/AWS/Environment/Types.hs
@@ -38,9 +38,9 @@ instance Show Environment where
 
 instance FromJSON Environment where
   parseJSON = withObject "AWS.Environment" \obj -> do
-    _accessKey  <- obj .: "access_key"
-    _secretKey  <- obj .: "secret_key"
-    _zoneID     <- obj .: "zone_id"
-    _domainName <- obj .: "domain_name"
+    _accessKey  <- obj .: "accessKey"
+    _secretKey  <- obj .: "secretKey"
+    _zoneID     <- obj .: "zoneId"
+    _domainName <- obj .: "domainName"
 
     return $ Environment {..}

--- a/library/Fission/AWS/Environment/Types.hs
+++ b/library/Fission/AWS/Environment/Types.hs
@@ -38,9 +38,9 @@ instance Show Environment where
 
 instance FromJSON Environment where
   parseJSON = withObject "AWS.Environment" \obj -> do
-    _accessKey  <- obj .: "accessKey"
-    _secretKey  <- obj .: "secretKey"
-    _zoneID     <- obj .: "zoneId"
-    _domainName <- obj .: "domainName"
+    _accessKey  <- obj .: "access_key"
+    _secretKey  <- obj .: "secret_key"
+    _zoneID     <- obj .: "zone_id"
+    _domainName <- obj .: "domain_name"
 
     return $ Environment {..}

--- a/library/Fission/Storage/Environment/Types.hs
+++ b/library/Fission/Storage/Environment/Types.hs
@@ -28,8 +28,8 @@ makeLenses ''Environment
 instance FromJSON Environment where
   parseJSON = withObject "Storage.Environment" \obj -> do
     _pgConnectInfo  <- obj .: "postgresql" >>= parseJSON . Object
-    _stripeCount    <- obj .: "stripeCount"
-    _connsPerStripe <- obj .: "connsPerStripe"
-    _connTTL        <- obj .: "connTTL"
+    _stripeCount    <- obj .: "stripe_count"
+    _connsPerStripe <- obj .: "conns_per_stripe"
+    _connTTL        <- obj .: "conn_ttl"
 
     return $ Environment {..}


### PR DESCRIPTION
**Summary**
Our server was failing to start as the `env.yaml` file had a convention of camelCase when the `AWS.Enivornment.Types` were incorrectly wanting snake_case.

This was compounded by the fact that:
1. We were only matching on Right
2. The error given by Left was very undescriptive
3. Relying on Haskell guessing the type of the yaml decode made repl debugging a little harder

This PR fixes/implements the following **bugs/features**

* [x] camelCase AWS config
* [x] Throw the actual error when parsing the yaml

# After Merge
Note that I have changed the config values for aws on the server temporarily to be snake_case to allow for a proper review.

Once this is merged we will need to change those values back to camelCase.

