### PR TITLE
Add optional path argument to Up and Watch

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -87,6 +87,7 @@ dependencies:
   - data-has
   - ekg-wai
   - envy
+  - filepath
   - fsnotify
   - haskeline
   - http-client


### PR DESCRIPTION
# Problem

You need to `cd` into a directory that you want to sync with `up` or `watch`

# Solution

Pass an optional argument to the CLI to specify a file path. May be a directory or a single file, absolute or relative

Closes https://github.com/fission-suite/web-api/issues/138