### PR TITLE
decrease ttl to 10 s

### DIFF
--- a/library/Fission/AWS/Route53.hs
+++ b/library/Fission/AWS/Route53.hs
@@ -54,5 +54,5 @@ createChangeRequest recordType domain content = do
 
 addValue :: ResourceRecordSet -> Text -> ResourceRecordSet
 addValue recordSet value =
-  recordSet & rrsTTL ?~ 300
+  recordSet & rrsTTL ?~ 10
             & rrsResourceRecords ?~ pure (resourceRecord value)


### PR DESCRIPTION
# Problem
DNS records stick around too long so users can't see updates to their app

# Solution
Decrease TTL of records from 300s to 10s