### PR TITLE
Set dns to point to splash on user register

### DIFF
--- a/library/Fission/Web/User.hs
+++ b/library/Fission/Web/User.hs
@@ -17,8 +17,8 @@ import qualified Fission.Web.User.Verify as Verify
 import qualified Fission.Web.Auth.Types  as Auth
 import qualified Fission.Web.Types       as Web
 
-import           Network.AWS.Auth as AWS
-import qualified Fission.AWS.Types   as AWS
+import           Network.AWS.Auth  as AWS
+import qualified Fission.AWS.Types as AWS
 
 type API = Create.API
       :<|> VerifyRoute

--- a/library/Fission/Web/User.hs
+++ b/library/Fission/Web/User.hs
@@ -17,6 +17,9 @@ import qualified Fission.Web.User.Verify as Verify
 import qualified Fission.Web.Auth.Types  as Auth
 import qualified Fission.Web.Types       as Web
 
+import           Network.AWS.Auth as AWS
+import qualified Fission.AWS.Types   as AWS
+
 type API = Create.API
       :<|> VerifyRoute
 
@@ -27,6 +30,10 @@ type VerifyRoute = "verify"
 server :: HasLogFunc        cfg
        => MonadSelda   (RIO cfg)
        => Has Web.Host      cfg
+       => Has AWS.DomainName    cfg
+       => Has AWS.AccessKey  cfg
+       => Has AWS.SecretKey  cfg
+       => Has AWS.ZoneID     cfg
        => RIOServer         cfg API
 server = Create.server
     :<|> const Verify.server

--- a/library/Fission/Web/User/Create.hs
+++ b/library/Fission/Web/User/Create.hs
@@ -20,6 +20,14 @@ import qualified Fission.User                     as User
 import qualified Fission.User.Provision.Types     as User
 import qualified Fission.User.Registration.Types  as User
 
+import           Fission.AWS
+import qualified Fission.AWS.Types   as AWS
+import           Fission.AWS.Route53
+
+import           Network.AWS.Auth as AWS
+import qualified Network.AWS.Route53 as Route53
+
+import           Fission.Internal.UTF8
 import           Fission.Security.Types (Secret (..))
   
 type API = ReqBody '[JSON] User.Registration 
@@ -28,15 +36,32 @@ type API = ReqBody '[JSON] User.Registration
 
 server :: HasLogFunc      cfg
        => Has Web.Host    cfg
+       => Has AWS.DomainName    cfg
+       => Has AWS.AccessKey  cfg
+       => Has AWS.SecretKey  cfg
+       => Has AWS.ZoneID     cfg
        => MonadSelda (RIO cfg)
        => RIOServer       cfg API
 server (User.Registration username password email) = do
   Web.Host url <- Config.get
+  domain :: AWS.DomainName <- Config.get
   userID       <- User.create username password email
   logInfo $ "Provisioned user: " <> displayShow userID
+
+  let
+    baseUrl    = username <> AWS.getDomainName domain
+    dnslinkUrl = "_dnslink." <> baseUrl
+    dnslink    = "dnslink=/ipfs/" <> splashCID
+
+  ensureContent $ registerDomain Route53.Cname baseUrl "ipfs.runfission.com"
+  ensureContent $ registerDomain Route53.Txt dnslinkUrl $ dnslink `wrapIn` "\""
+
 
   return User.Provision
     { _url      = url
     , _username = username
     , _password = Secret password
     }
+
+splashCID :: Text
+splashCID = "QmRVvvMeMEPi1zerpXYH9df3ATdzuB63R1wf3Mz5NS5HQN"

--- a/library/Fission/Web/User/Create.hs
+++ b/library/Fission/Web/User/Create.hs
@@ -34,14 +34,14 @@ type API = ReqBody '[JSON] User.Registration
         :> Post '[JSON] User.Provision
 
 
-server :: HasLogFunc      cfg
-       => Has Web.Host    cfg
-       => Has AWS.DomainName    cfg
+server :: HasLogFunc         cfg
+       => Has Web.Host       cfg
+       => Has AWS.DomainName cfg
        => Has AWS.AccessKey  cfg
        => Has AWS.SecretKey  cfg
        => Has AWS.ZoneID     cfg
-       => MonadSelda (RIO cfg)
-       => RIOServer       cfg API
+       => MonadSelda    (RIO cfg)
+       => RIOServer          cfg API
 server (User.Registration username password email) = do
   domain :: AWS.DomainName <- Config.get
   Web.Host url            <- Config.get

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-api
-version: '1.16.0'
+version: '1.17.0'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
# Problem
Initial DNS propagation takes awhile, subsequent updates are much faster.

# Solution
Set dns to point to a fission splash screen on user register. Then initial `up` will be much faster