### PR TITLE
add whoami cli command

### DIFF
--- a/library/Fission/CLI.hs
+++ b/library/Fission/CLI.hs
@@ -17,6 +17,7 @@ import qualified Fission.CLI.Command.Register as Register
 import qualified Fission.CLI.Command.Up       as Up
 import qualified Fission.CLI.Command.Down     as Down
 import qualified Fission.CLI.Command.Watch    as Watch
+import qualified Fission.CLI.Command.Whoami   as Whoami
 
 -- | Top-level CLI description
 cli :: MonadRIO    cfg m
@@ -35,6 +36,7 @@ cli = do
     Up.command       cfg
     Down.command     cfg
     Watch.command    cfg
+    Whoami.command   cfg
   runCLI
   where
     version     = "1.15.1"

--- a/library/Fission/CLI/Command/Whoami.hs
+++ b/library/Fission/CLI/Command/Whoami.hs
@@ -1,0 +1,48 @@
+-- | Whoami command
+module Fission.CLI.Command.Whoami (command, whoami) where
+
+import           RIO
+import           RIO.ByteString
+
+import           Options.Applicative.Simple (addCommand)
+import           Servant
+
+import qualified Data.ByteString.Char8 as BS
+import qualified System.Console.ANSI as ANSI
+
+import           Fission.Internal.Constraint
+import qualified Fission.Internal.UTF8 as UTF8
+
+import qualified Fission.CLI.Auth as Auth
+import           Fission.CLI.Config.Types
+
+
+-- | The command to attach to the CLI tree
+command :: MonadIO m
+        => HasLogFunc cfg
+        => cfg
+        -> CommandM (m ())
+command cfg =
+  addCommand
+    "whoami"
+    "Check the current user"
+    (const $ runRIO cfg whoami)
+    (pure ())
+
+whoami :: MonadRIO   cfg m
+       => HasLogFunc cfg
+       => m ()
+whoami = do
+  Auth.get >>= \case
+    Left err -> do
+      logError $ displayShow err
+      Auth.couldNotRead
+
+    Right auth -> do
+      let username = basicAuthUsername auth
+      UTF8.putText "💻 Currently logged in as: "
+
+      liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
+      putStr $ BS.append username "\n"
+
+      liftIO $ ANSI.setSGR [ANSI.Reset]

--- a/library/Fission/CLI/Command/Whoami.hs
+++ b/library/Fission/CLI/Command/Whoami.hs
@@ -39,10 +39,9 @@ whoami = do
       Auth.couldNotRead
 
     Right auth -> do
-      let username = basicAuthUsername auth
       UTF8.putText "💻 Currently logged in as: "
 
       liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
-      putStr $ BS.append username "\n"
+      putStr $ basicAuthUsername auth <> "\n"
 
       liftIO $ ANSI.setSGR [ANSI.Reset]


### PR DESCRIPTION
# Problem
Users have to check `~/.fission.yaml` to determine who they're currently logged in as

# Solution
Add `whoami` command that prints user's username

Closes https://github.com/fission-suite/web-api/issues/161