### PR TITLE
Fission CLI logout

### DIFF
--- a/library/Fission/CLI.hs
+++ b/library/Fission/CLI.hs
@@ -13,6 +13,7 @@ import qualified Fission.Web.Client   as Client
 import qualified Fission.IPFS.Types   as IPFS
 
 import qualified Fission.CLI.Command.Login    as Login
+import qualified Fission.CLI.Command.Logout   as Logout
 import qualified Fission.CLI.Command.Register as Register
 import qualified Fission.CLI.Command.Up       as Up
 import qualified Fission.CLI.Command.Down     as Down
@@ -32,6 +33,7 @@ cli = do
   cfg <- ask
   (_, runCLI) <- liftIO $ simpleOptions version description detail (pure ()) do
     Login.command    cfg
+    Logout.command    cfg
     Register.command cfg
     Up.command       cfg
     Down.command     cfg

--- a/library/Fission/CLI/Auth.hs
+++ b/library/Fission/CLI/Auth.hs
@@ -4,6 +4,7 @@ module Fission.CLI.Auth
   , withAuth
   , write
   , couldNotRead
+  , removeConfigFile
   ) where
 
 import           RIO           hiding (set)
@@ -46,6 +47,12 @@ couldNotRead = do
   UTF8.putText "fission-cli login"
 
   liftIO $ ANSI.setSGR [ANSI.Reset]
+-- | Removes the users config file
+-- removeConfigFile :: MonadIO m => m FilePath
+removeConfigFile :: MonadUnliftIO m => m (Either IOException ())
+removeConfigFile = do
+  path <- cachePath
+  try $ removeFile path
 
 withAuth :: MonadRIO   cfg m
          => HasLogFunc cfg

--- a/library/Fission/CLI/Auth.hs
+++ b/library/Fission/CLI/Auth.hs
@@ -47,8 +47,8 @@ couldNotRead = do
   UTF8.putText "fission-cli login"
 
   liftIO $ ANSI.setSGR [ANSI.Reset]
+
 -- | Removes the users config file
--- removeConfigFile :: MonadIO m => m FilePath
 removeConfigFile :: MonadUnliftIO m => m (Either IOException ())
 removeConfigFile = do
   path <- cachePath
@@ -68,4 +68,3 @@ withAuth action = get >>= \case
     logError $ displayShow err
     couldNotRead
     return . Left $ toException err
-

--- a/library/Fission/CLI/Command/Logout.hs
+++ b/library/Fission/CLI/Command/Logout.hs
@@ -1,0 +1,44 @@
+-- | Login command
+module Fission.CLI.Command.Logout (command, logout) where
+
+import           RIO
+
+import           Options.Applicative.Simple (addCommand)
+
+import           Fission.Internal.Constraint
+
+import qualified Fission.CLI.Auth as Auth
+import           Fission.CLI.Config.Types
+
+import qualified Fission.CLI.Display.Success as CLI.Success
+import qualified Fission.CLI.Display.Error   as CLI.Error
+
+-- | The command to attach to the CLI tree
+command :: MonadIO m
+        => HasLogFunc        cfg
+        => cfg
+        -> CommandM (m ())
+command cfg =
+  addCommand
+    "logout"
+    "Logout of your Fission account"
+    (const $ runRIO cfg logout)
+    (pure ())
+
+-- | Login (i.e. save credentials to disk). Validates credentials agianst the server.
+logout :: MonadRIO          cfg m
+      => MonadUnliftIO         m
+      => HasLogFunc        cfg
+      => m ()
+logout = do
+  logDebug "Starting logout sequence"
+
+  possibleSuccess <- Auth.removeConfigFile
+
+  case possibleSuccess of
+    Right _ ->
+      CLI.Success.putOk "You are now logged out of the Fission CLI!"
+
+    Left err ->
+      CLI.Error.put err "Oh no! we were unable to remove your ~/.fission.yaml file for some reason. Please try again."
+

--- a/library/Fission/CLI/Display/Error.hs
+++ b/library/Fission/CLI/Display/Error.hs
@@ -8,6 +8,7 @@ import qualified System.Console.ANSI as ANSI
 import           Fission.Internal.Constraint
 import qualified Fission.Internal.UTF8 as UTF8
 
+-- | Display a given error to the user and log an error to the debug log.
 put :: (MonadRIO cfg m, HasLogFunc cfg, Show err) => err -> Text -> m ()
 put err msg = do
   logDebug $ displayShow err
@@ -15,6 +16,7 @@ put err msg = do
   UTF8.putText $ "🚫 " <> msg <> "\n"
   liftIO $ ANSI.setSGR [ANSI.Reset]
 
+-- | Display a generic error message to the user and log an error to the debug log.
 put' :: (MonadRIO cfg m, HasLogFunc cfg, Show err) => err -> m ()
 put' err = put err $ mconcat
   [ "Something went wrong. Please try again or file a bug report with "


### PR DESCRIPTION
**Summary**
Adds a `logout` command to the CLI that removes the `.fission.yaml` file

