### PR TITLE
Add --dns-only flag

### DIFF
--- a/library/Fission/CLI/Command/Down.hs
+++ b/library/Fission/CLI/Command/Down.hs
@@ -30,7 +30,7 @@ command :: MonadRIO          cfg m
 command cfg =
   addCommand
     "down"
-    "pull a ipfs or ipns object down to your system"
+    "Pull a ipfs or ipns object down to your system"
     (\cid -> runRIO cfg $ down cid)
     (strArgument $ mconcat
       [ metavar "ContentID"

--- a/library/Fission/CLI/Command/Up.hs
+++ b/library/Fission/CLI/Command/Up.hs
@@ -3,7 +3,6 @@ module Fission.CLI.Command.Up (command, up) where
 
 import           RIO
 import           RIO.Directory
-import           RIO.FilePath
 import           RIO.Process (HasProcessContext)
 
 import           Data.Has
@@ -49,7 +48,7 @@ up :: MonadRIO          cfg m
    => Up.Options
    -> m ()
 up Up.Options {..} = handleWith_ Error.put' do
-  absPath <- toAbsolute path
+  absPath <- liftIO $ makeAbsolute path
   cid     <- liftE $ IPFS.addDir path
 
   logDebug $ "Starting single IPFS add locally of " <> displayShow absPath
@@ -58,15 +57,6 @@ up Up.Options {..} = handleWith_ Error.put' do
     void . liftE . Auth.withAuth $ CLI.Pin.run cid
 
   liftE . Auth.withAuth $ CLI.DNS.update cid
-
-toAbsolute :: MonadIO m => FilePath -> m FilePath
-toAbsolute path =
-  if isAbsolute path
-     then
-       return path
-     else do
-       currDir <- getCurrentDirectory
-       return $ currDir </> path
 
 parseOptions :: Parser Up.Options
 parseOptions = do

--- a/library/Fission/CLI/Command/Up.hs
+++ b/library/Fission/CLI/Command/Up.hs
@@ -17,6 +17,7 @@ import qualified Fission.Storage.IPFS as IPFS
 import qualified Fission.IPFS.Types   as IPFS
 import qualified Fission.Web.Client   as Client
 
+import           Fission.CLI.Command.Up.Types
 import qualified Fission.CLI.Display.Error as Error
 import qualified Fission.CLI.Auth          as Auth
 import qualified Fission.CLI.Pin           as CLI.Pin
@@ -38,12 +39,6 @@ command cfg =
     "Keep your current working directory up"
     (runRIO cfg . up)
     commandOptionsParser
-
-
-data CommandOptions = CommandOptions
-  { optDnsOnly :: Bool
-  , optLocation :: String
-  }
 
 
 commandOptionsParser :: Parser CommandOptions

--- a/library/Fission/CLI/Command/Up.hs
+++ b/library/Fission/CLI/Command/Up.hs
@@ -53,7 +53,7 @@ up Up.Options {..} = handleWith_ Error.put' do
 
   logDebug $ "Starting single IPFS add locally of " <> displayShow absPath
 
-  when (not dnsOnly) do
+  unless dnsOnly do
     void . liftE . Auth.withAuth $ CLI.Pin.run cid
 
   liftE . Auth.withAuth $ CLI.DNS.update cid
@@ -62,13 +62,12 @@ parseOptions :: Parser Up.Options
 parseOptions = do
   dnsOnly <- switch $ mconcat
     [ long "dns-only"
-    , help "Don't upload anything to Fission"
+    , help "Only update DNS (skip file sync)"
     ]
 
   path <- strArgument $ mconcat
-    [ metavar "Location"
-    , help    "The location of the assets you want to upload"
-    , value   "./"
+    [ metavar "PATH"
+    , help    "The file path of the assets or directory to sync"
     ]
 
   return Up.Options {..}

--- a/library/Fission/CLI/Command/Up/Types.hs
+++ b/library/Fission/CLI/Command/Up/Types.hs
@@ -1,10 +1,9 @@
-module Fission.CLI.Command.Up.Types (CommandOptions(..)) where
+module Fission.CLI.Command.Up.Types (Options(..)) where
 
 import RIO
 
-
 -- | Arguments, flags & switches for the `up` command
-data CommandOptions = CommandOptions
-  { optDnsOnly :: Bool
-  , optLocation :: String
+data Options = Options
+  { dnsOnly :: Bool
+  , path    :: FilePath
   }

--- a/library/Fission/CLI/Command/Up/Types.hs
+++ b/library/Fission/CLI/Command/Up/Types.hs
@@ -1,0 +1,10 @@
+module Fission.CLI.Command.Up.Types (CommandOptions(..)) where
+
+import RIO
+
+
+-- | Arguments, flags & switches for the `up` command
+data CommandOptions = CommandOptions
+  { optDnsOnly :: Bool
+  , optLocation :: String
+  }

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -7,7 +7,6 @@ module Fission.CLI.Command.Watch
 
 import           RIO
 import           RIO.Directory
-import           RIO.FilePath
 import           RIO.Process (HasProcessContext)
 import qualified RIO.Text as Text
 import           RIO.Time
@@ -64,7 +63,7 @@ watcher :: MonadRIO          cfg m
         -> m ()
 watcher Watch.Options {..} = handleWith_ CLI.Error.put' do
   cfg            <- ask
-  absPath        <- toAbsolute path
+  absPath        <- makeAbsolute path
   cid@(CID hash) <- liftE $ IPFS.addDir absPath
 
   UTF8.putText $ "👀 Watching " <> Text.pack absPath <> " for changes...\n"
@@ -143,12 +142,3 @@ parseOptions = do
     ]
 
   return Watch.Options {..}
-
-toAbsolute :: MonadIO m => FilePath -> m FilePath
-toAbsolute path =
-  if isAbsolute path
-     then
-       return path
-     else do
-       currDir <- getCurrentDirectory
-       return $ currDir </> path

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -126,7 +126,7 @@ pinAndUpdateDNS cid =
       logError $ displayShow err
       return $ Left err
 
-    Right _ -> do
+    Right _ ->
       Auth.withAuth $ CLI.DNS.update cid
 
 parseOptions :: Parser Watch.Options

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -31,11 +31,11 @@ import qualified Fission.AWS.Types  as AWS
 import           Fission.Internal.Exception
 import           Fission.CLI.Display.Error as CLI.Error
 
-import qualified Fission.CLI.Auth          as Auth
-import           Fission.CLI.Command.Watch.Types
+import qualified Fission.CLI.Auth                as Auth
+import           Fission.CLI.Command.Watch.Types as Watch
 import           Fission.CLI.Config.Types
-import qualified Fission.CLI.Pin           as CLI.Pin
-import qualified Fission.CLI.DNS           as CLI.DNS
+import qualified Fission.CLI.Pin                 as CLI.Pin
+import qualified Fission.CLI.DNS                 as CLI.DNS
 
 -- | The command to attach to the CLI tree
 command :: MonadIO m
@@ -50,35 +50,8 @@ command cfg =
   addCommand
     "watch"
     "Keep your working directory in sync with the IPFS network"
-    (runRIO cfg . watcher)
-    commandOptionsParser
-
-
-commandOptionsParser :: Parser CommandOptions
-commandOptionsParser = do
-  optDnsOnly <- dnsOnly
-  optLocation <- location
-
-  pure CommandOptions {..}
-
-  where
-    dnsOnly :: Parser Bool
-    dnsOnly =
-      [ long "dns-only"
-      , help "Don't upload anything to Fission"
-      ]
-      & mconcat
-      & flag False True
-
-    location :: Parser String
-    location =
-      [ metavar "Location"
-      , help    "The location of the assets you want to watch"
-      , value   "./"
-      ]
-      & mconcat
-      & strArgument
-
+    (\options -> runRIO cfg $ watcher options)
+    parseOptions
 
 -- | Continuously sync the current working directory to the server over IPFS
 watcher :: MonadRIO          cfg m
@@ -87,40 +60,24 @@ watcher :: MonadRIO          cfg m
         => HasProcessContext cfg
         => Has IPFS.BinPath  cfg
         => Has IPFS.Timeout  cfg
-        => CommandOptions
+        => Watch.Options
         -> m ()
-watcher options = handleWith_ CLI.Error.put' do
-  let dir = optLocation options
-  let dnsOnly = optDnsOnly options
+watcher Watch.Options {..} = handleWith_ CLI.Error.put' do
+  cfg            <- ask
+  absPath        <- toAbsolute path
+  cid@(CID hash) <- liftE $ IPFS.addDir absPath
 
-  cfg <- ask
-  curr <- getCurrentDirectory
+  UTF8.putText $ "👀 Watching " <> Text.pack absPath <> " for changes...\n"
 
-  let absDir = if isAbsolute dir then dir else curr </> dir
-  UTF8.putText $ "👀 Watching " <> Text.pack dir <> " for changes...\n"
+  when (not dnsOnly) do
+    void . liftE . Auth.withAuth $ CLI.Pin.run cid
 
-  -- Add directory to local IPFS
-  cid@(CID hash) <- liftE $ IPFS.addDir absDir
-
-  -- Pin the content on Fission if needed
-  if dnsOnly then
-    return ()
-  else
-    hash
-      & CID
-      & CLI.Pin.run
-      & Auth.withAuth
-      & liftE
-      & fmap (\_ -> ())
-
-  -- Update DNS
   liftE . Auth.withAuth $ CLI.DNS.update cid
 
-  -- Watch for new changes
   liftIO $ FS.withManager \watchMgr -> do
     hashCache <- newMVar hash
     timeCache <- newMVar =<< getCurrentTime
-    void $ handleTreeChanges timeCache hashCache watchMgr cfg absDir
+    void $ handleTreeChanges timeCache hashCache watchMgr cfg absPath
     forever $ liftIO $ threadDelay 1000000 -- Sleep main thread
 
 handleTreeChanges :: HasLogFunc        cfg
@@ -135,25 +92,22 @@ handleTreeChanges :: HasLogFunc        cfg
                   -> FilePath
                   -> IO StopListening
 handleTreeChanges timeCache hashCache watchMgr cfg dir =
-  FS.watchTree watchMgr dir (const True) \_ -> runRIO cfg do
+  FS.watchTree watchMgr dir (\_ -> True) \_ -> runRIO cfg do
     now     <- getCurrentTime
     oldTime <- readMVar timeCache
 
-    if diffUTCTime now oldTime < Time.doherty
-      then
-        logDebug "Fired within change lock window"
+    unless (diffUTCTime now oldTime < Time.doherty) do
+      void $ swapMVar timeCache now
+      threadDelay Time.dohertyMicroSeconds -- Wait for all events to fire in sliding window
 
-      else do
-        void $ swapMVar timeCache now
-        threadDelay Time.dohertyMicroSeconds -- Wait for all events to fire in sliding window
-        IPFS.addDir dir >>= \case
-          Left err ->
-            CLI.Error.put' err
+      IPFS.addDir dir >>= \case
+        Left err ->
+          CLI.Error.put' err
 
-          Right cid@(CID newHash) -> do
-            oldHash <- swapMVar hashCache newHash
-            logDebug $ "CID: " <> display oldHash <> " -> " <> display newHash
-            when (oldHash /= newHash) . void $ pinAndUpdateDNS cid
+        Right cid@(CID newHash) -> do
+          oldHash <- swapMVar hashCache newHash
+          logDebug $ "CID: " <> display oldHash <> " -> " <> display newHash
+          when (oldHash /= newHash) . void $ pinAndUpdateDNS cid
 
 pinAndUpdateDNS :: MonadRIO          cfg m
                 => HasLogFunc        cfg
@@ -171,3 +125,27 @@ pinAndUpdateDNS cid =
 
     Right _ ->
       Auth.withAuth $ CLI.DNS.update cid
+
+parseOptions :: Parser Watch.Options
+parseOptions = do
+  dnsOnly <- switch $ mconcat
+    [ long "dns-only"
+    , help "Don't upload anything to Fission"
+    ]
+
+  path <- strArgument $ mconcat
+    [ metavar "Location"
+    , help    "The location of the assets you want to watch"
+    , value   "./"
+    ]
+
+  return Watch.Options {..}
+
+toAbsolute :: MonadIO m => FilePath -> m FilePath
+toAbsolute path =
+  if isAbsolute path
+     then
+       return path
+     else do
+       currDir <- getCurrentDirectory
+       return $ currDir </> path

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -32,6 +32,7 @@ import           Fission.Internal.Exception
 import           Fission.CLI.Display.Error as CLI.Error
 
 import qualified Fission.CLI.Auth          as Auth
+import           Fission.CLI.Command.Watch.Types
 import           Fission.CLI.Config.Types
 import qualified Fission.CLI.Pin           as CLI.Pin
 import qualified Fission.CLI.DNS           as CLI.DNS
@@ -51,12 +52,6 @@ command cfg =
     "Keep your working directory in sync with the IPFS network"
     (runRIO cfg . watcher)
     commandOptionsParser
-
-
-data CommandOptions = CommandOptions
-  { optDnsOnly :: Bool
-  , optLocation :: String
-  }
 
 
 commandOptionsParser :: Parser CommandOptions

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -132,13 +132,12 @@ parseOptions :: Parser Watch.Options
 parseOptions = do
   dnsOnly <- switch $ mconcat
     [ long "dns-only"
-    , help "Don't upload anything to Fission"
+    , help "Only update DNS (i.e. don't actively sync files to the server)"
     ]
 
   path <- strArgument $ mconcat
-    [ metavar "Location"
-    , help    "The location of the assets you want to watch"
-    , value   "./"
+    [ metavar "PATH"
+    , help    "The file path of the assets or directory to watch"
     ]
 
   return Watch.Options {..}

--- a/library/Fission/CLI/Command/Watch/Types.hs
+++ b/library/Fission/CLI/Command/Watch/Types.hs
@@ -1,0 +1,10 @@
+module Fission.CLI.Command.Watch.Types (CommandOptions(..)) where
+
+import RIO
+
+
+-- | Arguments, flags & switches for the `watch` command
+data CommandOptions = CommandOptions
+  { optDnsOnly :: Bool
+  , optLocation :: String
+  }

--- a/library/Fission/CLI/Command/Watch/Types.hs
+++ b/library/Fission/CLI/Command/Watch/Types.hs
@@ -1,10 +1,9 @@
-module Fission.CLI.Command.Watch.Types (CommandOptions(..)) where
+module Fission.CLI.Command.Watch.Types (Options(..)) where
 
 import RIO
 
-
 -- | Arguments, flags & switches for the `watch` command
-data CommandOptions = CommandOptions
-  { optDnsOnly :: Bool
-  , optLocation :: String
+data Options = Options
+  { dnsOnly :: Bool
+  , path    :: FilePath
   }

--- a/library/Fission/CLI/Command/Whoami.hs
+++ b/library/Fission/CLI/Command/Whoami.hs
@@ -7,7 +7,6 @@ import           RIO.ByteString
 import           Options.Applicative.Simple (addCommand)
 import           Servant
 
-import qualified Data.ByteString.Char8 as BS
 import qualified System.Console.ANSI as ANSI
 
 import           Fission.Internal.Constraint
@@ -15,7 +14,6 @@ import qualified Fission.Internal.UTF8 as UTF8
 
 import qualified Fission.CLI.Auth as Auth
 import           Fission.CLI.Config.Types
-
 
 -- | The command to attach to the CLI tree
 command :: MonadIO m

--- a/library/Fission/CLI/Display/Success.hs
+++ b/library/Fission/CLI/Display/Success.hs
@@ -24,5 +24,5 @@ putOk msg = do
 
 dnsUpdated :: MonadIO m => Text -> m ()
 dnsUpdated domain = do
-  UTF8.putText "📝 DNS Updated. Check out your site at: \n"
+  UTF8.putText "📝 DNS updated! Check out your site at: \n"
   UTF8.putText $ "🔗 " <> domain  <> "\n"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-api
-version: '1.16.0'
+version: '1.18.0'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **features**

* [x] Add `--dns-only` flag to the `up` command
* [x] Add `--dns-only` flag to the `watch` command

_Motivation:_

I want to use the Fission CLI to keep track of my music on my local machine, without uploading all the music to the Fission "gateway". Otherwise the gateway would need to download too much data.

_Usecase:_

1. Go to music directory
2. `fission watch`
3. Add `_dnslink.fission.domain` as a source on [Diffuse](https://diffuse.sh/)
4. 🎵

**Test plan (required)**

Tested by pointing the CLI at local server, and seeing if any non-dns requests came through.