### PR TITLE
Rename watch to dev, dev to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ package = fission-web-api
 stack_yaml = STACK_YAML="stack.yaml"
 stack = $(stack_yaml) stack
 
-dev:
+build:
 	$(stack) build --fast $(package):lib
 
 release:
@@ -30,7 +30,7 @@ test-ghci:
 bench:
 	$(stack) build --fast --bench $(package)
 
-watch:
+dev:
 	$(stack) exec -- ghcid -c "stack ghci $(package):lib --test --main-is $(package):fission-web"
 
 live:

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ curl \
 
 # Development
 
-There is a `Makefile` filled with helpful commands. The most used in development is `make watch`.
+There is a `Makefile` filled with helpful commands. The most used in development is `make dev`.
 
 ```shell
 # Install development tools
 make setup
 
 # Watch project for changes, validating types and syntax
-make watch
+make dev
 
 # Run the server and live reload
 make live


### PR DESCRIPTION
# Overview
Simple change suggested by @expede 
Rename the following make commands
- `watch` -> `dev`
- `dev` -> `build`