### PR TITLE
Fix #140: Heroku Deprovision 406

### DIFF
--- a/library/Fission/Web/Error.hs
+++ b/library/Fission/Web/Error.hs
@@ -64,6 +64,7 @@ ensure :: MonadRIO   cfg m
        => HasLogFunc cfg
        => MonadThrow     m
        => Display       err
+       => Exception     err
        => ToServerError err
        => Either err a
        -> m a
@@ -78,6 +79,7 @@ ensureM = either throwM pure
 
 ensureMaybe :: MonadRIO   cfg m
             => MonadThrow     m
+            -- => Exception err
             => ServerError
             -> Maybe a
             -> m a
@@ -86,14 +88,15 @@ ensureMaybe err = maybe (throwM err) pure
 throw :: MonadRIO   cfg m
       => HasLogFunc cfg
       => MonadThrow     m
+      => Exception     err
       => Display       err
       => ToServerError err
       => err
       -> m a
 throw err = do
-  let
-    serverError@(ServerError {..}) = toServerError err
-    status = Status errHTTPCode $ Lazy.toStrict errBody
+  -- let
+  --   serverError@(ServerError {..}) = toServerError err
+  --   status = Status errHTTPCode $ Lazy.toStrict errBody
 
-  when (statusIsServerError status) (logError $ display err)
-  throwM serverError
+  -- when (statusIsServerError status) (logError $ display err)
+  throwM err

--- a/library/Fission/Web/Error.hs
+++ b/library/Fission/Web/Error.hs
@@ -64,7 +64,6 @@ ensure :: MonadRIO   cfg m
        => HasLogFunc cfg
        => MonadThrow     m
        => Display       err
-       => Exception     err
        => ToServerError err
        => Either err a
        -> m a
@@ -79,7 +78,6 @@ ensureM = either throwM pure
 
 ensureMaybe :: MonadRIO   cfg m
             => MonadThrow     m
-            -- => Exception err
             => ServerError
             -> Maybe a
             -> m a
@@ -88,15 +86,14 @@ ensureMaybe err = maybe (throwM err) pure
 throw :: MonadRIO   cfg m
       => HasLogFunc cfg
       => MonadThrow     m
-      => Exception     err
       => Display       err
       => ToServerError err
       => err
       -> m a
 throw err = do
-  -- let
-  --   serverError@(ServerError {..}) = toServerError err
-  --   status = Status errHTTPCode $ Lazy.toStrict errBody
+  let
+    serverError@(ServerError {..}) = toServerError err
+    status = Status errHTTPCode $ Lazy.toStrict errBody
 
-  -- when (statusIsServerError status) (logError $ display err)
-  throwM err
+  when (statusIsServerError status) (logError $ display err)
+  throwM serverError

--- a/library/Fission/Web/Heroku.hs
+++ b/library/Fission/Web/Heroku.hs
@@ -114,7 +114,7 @@ deprovision :: MonadSelda   (RIO cfg)
             => Has IPFS.URL      cfg
             => RIOServer         cfg DeprovisionAPI
 deprovision uuid' = do
-  let err = Web.Err.ensureMaybe err404
+  let err = Web.Err.ensureMaybe err410 -- HTTP 410 is specified by the Heroku AddOn docs
 
   AddOn {_addOnID} <- err =<< Query.oneEq Table.addOns AddOn.uuid' uuid'
   User  {_userID}  <- err =<< Query.findOne do

--- a/library/Fission/Web/Heroku.hs
+++ b/library/Fission/Web/Heroku.hs
@@ -79,11 +79,11 @@ provision Request {_uuid, _region} = do
                      logError $ displayShow err
                      return []
 
-  username     <- liftIO $ User.genID 
+  username     <- liftIO $ User.genID
   secret       <- liftIO $ Random.text 200
   User.createWithHeroku _uuid _region username secret >>= \case
     Left err -> Web.Err.throw err
-    Right userID -> do 
+    Right userID -> do
       logInfo $ mconcat
         [ "Provisioned UUID: "
         , displayShow _uuid
@@ -106,7 +106,7 @@ provision Request {_uuid, _region} = do
         }
 
 type DeprovisionAPI = Capture "addon_id" UUID
-                   :> DeleteNoContent '[PlainText, OctetStream, JSON] NoContent
+                   :> DeleteNoContent '[Heroku.MIME.VendorJSONv3] NoContent
 
 deprovision :: MonadSelda   (RIO cfg)
             => HasLogFunc        cfg
@@ -116,7 +116,7 @@ deprovision :: MonadSelda   (RIO cfg)
 deprovision uuid' = do
   let err = Web.Err.ensureMaybe err404
 
-  AddOn {_addOnID} <- err =<< Query.oneEq Table.addOns AddOn.uuid'         uuid'
+  AddOn {_addOnID} <- err =<< Query.oneEq Table.addOns AddOn.uuid' uuid'
   User  {_userID}  <- err =<< Query.findOne do
     user <- select Table.users
     restrict $ user ! #_herokuAddOnId .== literal (Just _addOnID)

--- a/library/Fission/Web/Log.hs
+++ b/library/Fission/Web/Log.hs
@@ -22,7 +22,7 @@ rioApacheLogger :: MonadRIO   cfg m
 rioApacheLogger Request {..} Status {statusCode} _mayInt =
   if | statusCode >= 500 -> logError formatted
      | statusCode >= 400 -> logInfo  formatted
-     | otherwise        -> logDebug formatted
+     | otherwise         -> logDebug formatted
   where
     formatted :: Utf8Builder
     formatted = mconcat

--- a/library/Fission/Web/Server.hs
+++ b/library/Fission/Web/Server.hs
@@ -13,7 +13,7 @@ type RIOServer cfg api = ServerT api (RIO cfg)
 
 -- | Natural transformation to native Servant handler
 toHandler :: cfg -> RIO cfg a -> Handler a
-toHandler ctx a = Handler . ExceptT . try $ runReaderT (unRIO a) ctx
+toHandler cfg a = Handler . ExceptT . try $ runReaderT (unRIO a) cfg
 
 -- | Natural transformation into a RIO handler
 fromHandler :: Handler a -> RIO cfg a

--- a/library/Fission/Web/Server.hs
+++ b/library/Fission/Web/Server.hs
@@ -17,6 +17,7 @@ toHandler ctx a = Handler . ExceptT . try $ runReaderT (unRIO a) ctx
 
 -- | Natural transformation into a RIO handler
 fromHandler :: Handler a -> RIO cfg a
-fromHandler handler = liftIO $ runHandler handler >>= \case
-  Right inner     -> pure inner
-  Left servantErr -> throwM servantErr
+fromHandler handler =
+  liftIO $ runHandler handler >>= \case
+    Right inner     -> pure inner
+    Left servantErr -> throwM servantErr

--- a/library/Fission/Web/Server.hs
+++ b/library/Fission/Web/Server.hs
@@ -5,17 +5,16 @@ module Fission.Web.Server
   ) where
 
 import RIO hiding (Handler)
+
+import Control.Monad.Except
 import Servant
 
 type RIOServer cfg api = ServerT api (RIO cfg)
 
--- | Natural transformation to native Servant handler
-toHandler :: cfg -> RIO cfg a -> Handler a
-toHandler cfg = liftIO . runRIO cfg
-
 -- | Natural transformation into a RIO handler
 fromHandler :: Handler a -> RIO cfg a
-fromHandler handler =
-  liftIO $ runHandler handler >>= \case
-    Right inner     -> pure inner
-    Left servantErr -> throwM servantErr
+fromHandler handler = liftIO $ runHandler handler >>= either throwM pure
+
+-- | Natural transformation to native Servant handler
+toHandler :: cfg -> RIO cfg a -> Handler a
+toHandler ctx a = Handler . ExceptT . try $ runReaderT (unRIO a) ctx


### PR DESCRIPTION
# Problem

Tracking issue: #140 

The Heroku add-on API has been recording 406 ("Not Acceptable") errors on de-provisioning requests. It looks like the 406 is actually on their end. We're missing two details from their docs (see next section).

# Solution

## Content Type
Return a `Content-Type: application/vnd.heroku-addons+json; version=3`

## HTTP Status Code

Return a 410 on subsequent requests after 24 hours... or something? I dunno it's not totally clear. Using a 410 as failure when a record isn't found appears to be an acceptable response 🤷‍♀️ We _could_ update the add-on to track if it has been used in the past, and disambiguate between the 410 and 404, but that seems like more work than it's worth to make an external API happy.
