### PR TITLE
Change liblzma to libpq

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ in a familiar, compatible way
 brew install ipfs
 brew services start ipfs
 
-# If using Linux, install liblzma-dev
-# sudo apt install liblzma-dev
+# If using Linux, install libpq-dev
+# sudo apt install libpq-dev
 ```
 
 ## Setup config


### PR DESCRIPTION
# Problem
README still references `liblzma-dev` (sqlite) instead of `libpq-dev` (postgres)

# Solution
Change `liblzma` to `libpq`