### PR TITLE
Longer HTTP Timeout

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -67,18 +67,27 @@ main = do
 
     let
       Web.Port port' = _port
-      webLogger      = Web.Log.mkSettings _logFunc port'
+      settings       = mkSettings _logFunc port'
       runner         = if env ^. web . Web.isTLS then runTLS tlsSettings' else runSettings
       condDebug      = if env ^. web . Web.pretty then id else logStdoutDev
 
     when (env ^. web . Web.monitor) Monitor.wai
-    liftIO . runner webLogger
+    liftIO . runner settings
            . CORS.middleware
            . condDebug
            =<< Web.app
+
+mkSettings :: LogFunc -> Port -> Settings
+mkSettings logger port = defaultSettings
+                       & setPort port
+                       & setLogger (Web.Log.fromLogFunc logger)
+                       & setTimeout serverTimeout
 
 tlsSettings' :: TLSSettings
 tlsSettings' = tlsSettings "domain-crt.txt" "domain-key.txt"
 
 clientTimeout :: Int
 clientTimeout = 1800000000
+
+serverTimeout :: Int
+serverTimeout = 1800

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -57,6 +57,8 @@ main = do
   _dbPool      <- runSimpleApp $ connPool _stripeCount _connsPerStripe _connTTL _pgConnectInfo
   _processCtx  <- mkDefaultProcessContext
   _httpManager <- HTTP.newManager HTTP.defaultManagerSettings
+                   { HTTP.managerResponseTimeout = HTTP.responseTimeoutMicro clientTimeout }
+
   isVerbose    <- getFlag "RIO_VERBOSE" .!~ False
   logOptions   <- logOptionsHandle stdout isVerbose
 
@@ -77,3 +79,6 @@ main = do
 
 tlsSettings' :: TLSSettings
 tlsSettings' = tlsSettings "domain-crt.txt" "domain-key.txt"
+
+clientTimeout :: Int
+clientTimeout = 1800000000

--- a/library/Fission/Web/Log.hs
+++ b/library/Fission/Web/Log.hs
@@ -43,6 +43,7 @@ mkSettings :: LogFunc -> Port -> Settings
 mkSettings logger port = defaultSettings
                        & setPort port
                        & setLogger (fromLogFunc logger)
+                       & setTimeout 1800
 
 fromLogFunc :: LogFunc -> ApacheLogger
 fromLogFunc logger r s mi = runRIO logger (rioApacheLogger r s mi)

--- a/library/Fission/Web/Log.hs
+++ b/library/Fission/Web/Log.hs
@@ -1,6 +1,5 @@
 module Fission.Web.Log
   ( rioApacheLogger
-  , mkSettings
   , fromLogFunc
   ) where
 
@@ -8,7 +7,6 @@ import RIO
 
 import Network.HTTP.Types.Status
 import Network.Wai.Internal (Request (..))
-import Network.Wai.Handler.Warp
 import Network.Wai.Logger
 
 import Fission.Internal.Constraint
@@ -38,12 +36,6 @@ rioApacheLogger Request {..} Status {statusCode} _mayInt =
       , displayShow statusCode
       , displayShow $ maybe "" (" - " <>) requestHeaderUserAgent
       ]
-
-mkSettings :: LogFunc -> Port -> Settings
-mkSettings logger port = defaultSettings
-                       & setPort port
-                       & setLogger (fromLogFunc logger)
-                       & setTimeout 1800
 
 fromLogFunc :: LogFunc -> ApacheLogger
 fromLogFunc logger r s mi = runRIO logger (rioApacheLogger r s mi)


### PR DESCRIPTION
Increase timeout for both clients and requesting from IPFS node to 30 minutes.

We were experiencing issues where large pins were timing out, and propagating through to the CLI.

This is already running on prod as a quick fix. Merging to master now for consistency.