### PR TITLE
DNS Swagger Docs

### DIFF
--- a/library/Fission/Web/Swagger.hs
+++ b/library/Fission/Web/Swagger.hs
@@ -26,7 +26,8 @@ server :: Host -> RIOServer cfg API
 server = hoistServer (Proxy @API) fromHandler . swaggerSchemaUIServer . docs
 
 docs :: Host -> Swagger
-docs host' = ipfs
+docs host' = dns
+           . ipfs
            . heroku
            . ping
            . user
@@ -67,6 +68,10 @@ ipfs = makeDocs (Proxy @Web.IPFSRoute)
 ping :: Swagger -> Swagger
 ping = makeDocs (Proxy @Web.PingRoute)
   ["Ping" & description ?~ "Check for liveness"]
+
+dns :: Swagger -> Swagger
+dns = makeDocs (Proxy @Web.DNSRoute)
+  ["DNS" & description ?~ "Interact with DNS on AWS Route53"]
 
 makeDocs :: Servant.API.IsSubAPI subRoute Web.API
          => HasSwagger subRoute

--- a/library/Fission/Web/Swagger.hs
+++ b/library/Fission/Web/Swagger.hs
@@ -38,7 +38,7 @@ app proxy appHost = toSwagger proxy
                   & host               ?~ appHost
                   & schemes            ?~ [Https, Http]
                   & info . title       .~ "The Fission API"
-                  & info . version     .~ "1.12.0"
+                  & info . version     .~ "1.20.0"
                   & info . description ?~ blurb
                   & info . contact     ?~ fissionContact
                   & info . license     ?~ projectLicense
@@ -71,7 +71,7 @@ ping = makeDocs (Proxy @Web.PingRoute)
 
 dns :: Swagger -> Swagger
 dns = makeDocs (Proxy @Web.DNSRoute)
-  ["DNS" & description ?~ "Interact with DNS on AWS Route53"]
+  ["DNS" & description ?~ "DNS management"]
 
 makeDocs :: Servant.API.IsSubAPI subRoute Web.API
          => HasSwagger subRoute


### PR DESCRIPTION
## Problem
Missing swagger documentation on dns route. It just says `default`

## Solution
Add high-level swagger documentation to route