### PR TITLE
Basic text functions in `Fission.Prelude`

### DIFF
--- a/library/Fission/Internal/UTF8.hs
+++ b/library/Fission/Internal/UTF8.hs
@@ -12,11 +12,11 @@ module Fission.Internal.UTF8
   , wrapIn
   ) where
 
+import           Flow
+import           RIO
 import qualified RIO.ByteString      as Strict
 import qualified RIO.ByteString.Lazy as Lazy
 import qualified RIO.Text            as Text
-
-import Fission.Prelude hiding (encode)
 
 class Textable a where
   encode :: a -> Either UnicodeException Text

--- a/library/Fission/Internal/UTF8.hs
+++ b/library/Fission/Internal/UTF8.hs
@@ -1,6 +1,8 @@
+-- | UTF8 text helpers
 module Fission.Internal.UTF8
   ( Textable (..)
   , putText
+  , putTextLn
   , showLazyBS
   , stripN
   , stripNBS
@@ -56,6 +58,10 @@ stripN n = Text.dropEnd i . Text.drop i
 -- | Helper for printing 'Text' to a console
 putText :: MonadIO m => Text -> m ()
 putText = Strict.putStr . encodeUtf8
+
+-- | Helper for printing 'Text' to a console with a newline at the end
+putTextLn :: MonadIO m => Text -> m ()
+putTextLn txt = putText <| txt <> "\n"
 
 wrapIn :: Text -> Text -> Text
 wrapIn txt wrapper = wrapper <> txt <> wrapper

--- a/library/Fission/Prelude.hs
+++ b/library/Fission/Prelude.hs
@@ -14,6 +14,9 @@ module Fission.Prelude
   , headMaybe
   , identity
   , intercalate
+  , putText
+  , putTextLn
+  , textShow
   ) where
 
 import Control.Lens                ((%~), (.~), (?~), (^?))
@@ -22,6 +25,7 @@ import Data.Has
 import Data.Maybe
 import Data.Time                   (getCurrentTime)
 import Fission.Internal.Constraint
+import Fission.Internal.UTF8       (putText, putTextLn, textShow)
 import Flow
 import RIO                         hiding (Handler, id, timeout, ($), (&))
 import RIO.List                    (headMaybe, intercalate)


### PR DESCRIPTION
When reviewing a CLI PR, I realized that it may be helpful to have a printing function with automatic newlines. The base `Prelude` has `putStrLn`, which `RIO` eschews for some reason. In any case, here's some helpful functions by default to make it easier to default to printing each statement on a new line.