### PR TITLE
Return s3 node on /ipfs/peers

### DIFF
--- a/library/Fission/Web/IPFS/Peer.hs
+++ b/library/Fission/Web/IPFS/Peer.hs
@@ -22,5 +22,5 @@ get
      )
   => RIOServer cfg API
 get = getExternalAddress >>= \case
-  Right peers -> return <| [IPFS.Peer.fission ] <> peers
+  Right peers -> return (IPFS.Peer.fission : peers)
   Left err    -> Web.Err.throw err

--- a/library/Fission/Web/IPFS/Peer.hs
+++ b/library/Fission/Web/IPFS/Peer.hs
@@ -6,7 +6,7 @@ module Fission.Web.IPFS.Peer
 import           Servant
 
 import           Fission.Prelude
-import           Fission.IPFS.Peer
+import           Fission.IPFS.Peer as IPFS.Peer
 import           Fission.Web.Server
 import qualified Fission.IPFS.Types as IPFS
 import qualified Fission.Web.Error  as Web.Err
@@ -22,5 +22,5 @@ get
      )
   => RIOServer cfg API
 get = getExternalAddress >>= \case
-  Right peers -> return peers
+  Right peers -> return <| [IPFS.Peer.fission ] <> peers
   Left err    -> Web.Err.throw err


### PR DESCRIPTION
## Problem
GET /ipfs/peer only returns web-api node address

## Impact
When a user pins something, the s3 node has to through discover the user's node through the web-api node. Sometime's this takes longer than it should. We can skip that connectivity period by returning the s3 node address as well

##Solution
return s3 node address & web-api node address on GET /ipfs/peer

Closes https://github.com/fission-suite/web-api/issues/205