### PR TITLE
Gateway env

### DIFF
--- a/app/Fission/Environment/IPFS/Types.hs
+++ b/app/Fission/Environment/IPFS/Types.hs
@@ -8,12 +8,14 @@ data Environment = Environment
   { url     :: !IPFS.URL     -- ^ IPFS client URL (may be remote)
   , timeout :: !IPFS.Timeout -- ^ IPFS timeout in seconds
   , binPath :: !IPFS.BinPath -- ^ Path to local IPFS binary
+  , gateway :: !IPFS.Gateway -- ^ Domain Name of IPFS Gateway
   } deriving Show
 
 instance FromJSON Environment where
   parseJSON = withObject "IPFS.Environment" \obj -> do
     timeout <- obj .:? "timeout" .!= 3600
     binPath <- obj .:? "binPath" .!= "/usr/local/bin/ipfs"
+    gateway <- obj .:? "gateway" .!= "ipfs.runfission.com"
     url     <- obj .:  "url" >>= parseJSON . String
 
     return <| Environment {..}

--- a/app/Fission/Internal/Development.hs
+++ b/app/Fission/Internal/Development.hs
@@ -80,6 +80,7 @@ run logFunc dbPool processCtx httpManager action =
     ipfsPath    = "/usr/local/bin/ipfs"
     ipfsURL     = IPFS.URL <| BaseUrl Http "localhost" 5001 ""
     ipfsTimeout = IPFS.Timeout 3600
+    ipfsGateway    = IPFS.Gateway "ipfs.runfission.com"
 
     awsAccessKey  = "SOME_AWS_ACCESS_KEY"
     awsSecretKey  = "SOME_AWS_SECRET_KEY"
@@ -122,6 +123,7 @@ mkConfig dbPool processCtx httpManager logFunc = Config {..}
     ipfsPath       = "/usr/local/bin/ipfs"
     ipfsURL        = IPFS.URL <| BaseUrl Http "localhost" 5001 ""
     ipfsTimeout    = IPFS.Timeout 3600
+    ipfsGateway    = IPFS.Gateway "ipfs.runfission.com"
 
     awsAccessKey  = "SOME_AWS_ACCESS_KEY"
     awsSecretKey  = "SOME_AWS_SECRET_KEY"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -47,6 +47,7 @@ main = do
     ipfsPath    = env |> ipfs |> binPath
     ipfsURL     = env |> ipfs |> url
     ipfsTimeout = env |> ipfs |> IPFS.timeout
+    ipfsGateway = env |> ipfs |> gateway
 
     awsAccessKey  = accessKey
     awsSecretKey  = secretKey

--- a/example-config/env.yaml.example
+++ b/example-config/env.yaml.example
@@ -7,6 +7,7 @@ web:
 
 ipfs:
   url: http://localhost:5001
+  gateway: ipfs.runfission.com
   timeout: 3600
 
 storage:

--- a/library/Fission/AWS.hs
+++ b/library/Fission/AWS.hs
@@ -1,6 +1,5 @@
 module Fission.AWS
   ( createEnv
-  , ensureContent
   , validate
   , withAWS
   ) where
@@ -41,16 +40,3 @@ validate changeSet =
 
   where
     status = changeSet ^. crrsrsResponseStatus
-
--- | Ensure that a request completed, and that the status code is not in an error range
-ensureContent
-  :: ( MonadRIO   cfg m
-     , MonadThrow     m
-     , Exception err
-     )
-  => m (Either err ChangeResourceRecordSetsResponse)
-  -> m ChangeResourceRecordSetsResponse
-ensureContent runRequest = do
-  errOrResp <- runRequest
-  resp      <- ensureM errOrResp
-  resp |> validate |> ensureM

--- a/library/Fission/AWS/Route53.hs
+++ b/library/Fission/AWS/Route53.hs
@@ -41,12 +41,10 @@ registerDomain username (CID hash) = do
     dnslinkUrl = "_dnslink." <> baseUrl
     dnslink    = "dnslink=/ipfs/" <> hash
 
-  logDebug <| displayShow ("~~" <> (wrapIn dnslink "\"") <> "~~")
-
   changeRecord Cname baseUrl (getGateway gateway) >>= \case
     Left err -> return <| Left err
     Right _ -> 
-      changeRecord Txt dnslinkUrl (wrapIn dnslink "\"") >>= \case
+      changeRecord Txt dnslinkUrl (dnslink `wrapIn` "\"") >>= \case
         Left err -> return <| Left err
         Right _ -> return <| Right <| AWS.DomainName baseUrl
 

--- a/library/Fission/AWS/Route53.hs
+++ b/library/Fission/AWS/Route53.hs
@@ -3,30 +3,66 @@ module Fission.AWS.Route53
   , registerDomain
   ) where
 
-import Network.AWS
-import Network.AWS.Auth as AWS
-import Network.AWS.Prelude
-import Network.AWS.Route53
-import Servant
+import           Network.AWS
+import           Network.AWS.Auth as AWS
+import           Network.AWS.Prelude hiding (hash)
+import           Network.AWS.Route53
+import           Servant
 
 import           Fission.Prelude
+import           Fission.Internal.UTF8
 import qualified Fission.Config    as Config
 import           Fission.AWS.Types as AWS
 import           Fission.AWS
 
-registerDomain
-  :: ( MonadRIO           cfg m
-     , MonadUnliftIO          m
-     , HasLogFunc         cfg
-     , Has AWS.AccessKey  cfg
-     , Has AWS.SecretKey  cfg
-     , Has AWS.ZoneID     cfg
-     )
+import qualified Fission.IPFS.Types as IPFS
+import           Fission.IPFS.Gateway.Types
+import           Fission.IPFS.CID.Types
+
+registerDomain ::
+  ( MonadRIO           cfg m
+  , MonadUnliftIO          m
+  , HasLogFunc         cfg
+  , Has IPFS.Gateway   cfg
+  , Has AWS.AccessKey  cfg
+  , Has AWS.SecretKey  cfg
+  , Has AWS.ZoneID     cfg
+  , Has AWS.DomainName cfg
+  )
+  => Text
+  -> CID
+  -> m (Either ServerError AWS.DomainName)
+registerDomain username (CID hash) = do
+  gateway :: IPFS.Gateway   <- Config.get
+  domain  :: AWS.DomainName <- Config.get
+
+  let
+    baseUrl    = username <> "."<> AWS.getDomainName domain
+    dnslinkUrl = "_dnslink." <> baseUrl
+    dnslink    = "dnslink=/ipfs/" <> hash
+
+  logDebug <| displayShow ("~~" <> (wrapIn dnslink "\"") <> "~~")
+
+  changeRecord Cname baseUrl (getGateway gateway) >>= \case
+    Left err -> return <| Left err
+    Right _ -> 
+      changeRecord Txt dnslinkUrl (wrapIn dnslink "\"") >>= \case
+        Left err -> return <| Left err
+        Right _ -> return <| Right <| AWS.DomainName baseUrl
+
+changeRecord ::
+  ( MonadRIO           cfg m
+  , MonadUnliftIO          m
+  , HasLogFunc         cfg
+  , Has AWS.AccessKey  cfg
+  , Has AWS.SecretKey  cfg
+  , Has AWS.ZoneID     cfg
+  )
   => RecordType
   -> Text
   -> Text
   -> m (Either ServerError ChangeResourceRecordSetsResponse)
-registerDomain recordType domain content = do
+changeRecord recordType domain content = do
   logDebug <| "Updating DNS record at: " <> displayShow domain
   env <- createEnv
   req <- createChangeRequest recordType domain content
@@ -35,10 +71,10 @@ registerDomain recordType domain content = do
     res <- send req
     return <| validate res
 
-createChangeRequest
-  :: ( MonadRIO       cfg m
-     , Has AWS.ZoneID cfg
-     )
+createChangeRequest ::
+  ( MonadRIO       cfg m
+  , Has AWS.ZoneID cfg
+    )
   => RecordType
   -> Text
   -> Text

--- a/library/Fission/Config/Types.hs
+++ b/library/Fission/Config/Types.hs
@@ -19,6 +19,7 @@ data Config dbBackend = Config
   , ipfsPath       :: !IPFS.BinPath
   , ipfsURL        :: !IPFS.URL
   , ipfsTimeout    :: !IPFS.Timeout
+  , ipfsGateway    :: !IPFS.Gateway
   , host           :: !Host
   , dbPool         :: !(DB.Pool dbBackend)
   , herokuID       :: !Heroku.ID
@@ -38,6 +39,7 @@ instance Show (Config dbBackend) where
     , "  ipfsPath       = " <> show ipfsPath
     , "  ipfsURL        = " <> show ipfsURL
     , "  ipfsTimeout    = " <> show ipfsTimeout
+    , "  ipfsGateway    = " <> show ipfsGateway
     , "  host           = " <> show host
     , "  dbPool         = " <> show dbPool
     , "  herokuID       = " <> show herokuID
@@ -72,6 +74,10 @@ instance Has IPFS.URL (Config db) where
 instance Has IPFS.Timeout (Config db) where
   hasLens = lens ipfsTimeout \cfg newIPFSTimeout ->
     cfg { ipfsTimeout = newIPFSTimeout }
+
+instance Has IPFS.Gateway (Config db) where
+  hasLens = lens ipfsGateway \cfg newIPFSGateway ->
+    cfg { ipfsGateway = newIPFSGateway }
 
 instance Has (DB.Pool db) (Config db) where
   hasLens = lens dbPool \cfg newDBPool ->

--- a/library/Fission/IPFS/Gateway/Types.hs
+++ b/library/Fission/IPFS/Gateway/Types.hs
@@ -3,7 +3,8 @@ module Fission.IPFS.Gateway.Types (Gateway (..)) where
 import           Fission.Prelude
 import           Data.Swagger (ToSchema (..))
 
--- | Type safety wrapper for Route53 domain names
+-- | Type safety wrapper for IPFS Gateway
+--   Used as cname value for DNS updates
 newtype Gateway = Gateway { getGateway :: Text }
   deriving          ( Eq
                     , Generic

--- a/library/Fission/IPFS/Gateway/Types.hs
+++ b/library/Fission/IPFS/Gateway/Types.hs
@@ -1,0 +1,17 @@
+module Fission.IPFS.Gateway.Types (Gateway (..)) where
+
+import           Fission.Prelude
+import           Data.Swagger (ToSchema (..))
+
+-- | Type safety wrapper for Route53 domain names
+newtype Gateway = Gateway { getGateway :: Text }
+  deriving          ( Eq
+                    , Generic
+                    , Show
+                    )
+  deriving anyclass ( ToSchema )
+  deriving newtype  ( IsString )
+
+instance FromJSON Gateway where
+  parseJSON = withText "AWS.Gateway" \txt ->
+    Gateway <$> parseJSON (String txt)

--- a/library/Fission/IPFS/Types.hs
+++ b/library/Fission/IPFS/Types.hs
@@ -12,6 +12,7 @@ module Fission.IPFS.Types
   , Timeout (..)
   , URL (..)
   , Ignored
+  , Gateway (..)
   ) where
 
 import Fission.IPFS.BinPath.Types
@@ -24,3 +25,4 @@ import Fission.IPFS.SparseTree.Types
 import Fission.IPFS.Timeout.Types
 import Fission.IPFS.URL.Types
 import Fission.IPFS.Ignored.Types
+import Fission.IPFS.Gateway.Types

--- a/library/Fission/Web.hs
+++ b/library/Fission/Web.hs
@@ -48,6 +48,7 @@ app
   :: ( Has IPFS.BinPath    cfg
      , Has IPFS.Timeout    cfg
      , Has IPFS.URL        cfg
+     , Has IPFS.Gateway    cfg
      , Has HTTP.Manager    cfg
      , Has Web.Host        cfg
      , Has AWS.AccessKey   cfg
@@ -97,8 +98,9 @@ mkAuth = do
 server
   :: ( Has IPFS.BinPath   cfg
      , Has IPFS.Timeout   cfg
-     , Has HTTP.Manager   cfg
      , Has IPFS.URL       cfg
+     , Has IPFS.Gateway   cfg
+     , Has HTTP.Manager   cfg
      , Has Web.Host       cfg
      , Has AWS.AccessKey  cfg
      , Has AWS.SecretKey  cfg

--- a/library/Fission/Web/DNS.hs
+++ b/library/Fission/Web/DNS.hs
@@ -5,58 +5,33 @@ module Fission.Web.DNS
 
 
 import qualified Network.AWS.Auth    as AWS
-import qualified Network.AWS.Route53 as Route53
 import           Servant
 
 import           Fission.Prelude
 
-import           Fission.AWS
 import           Fission.AWS.Route53
 import qualified Fission.AWS.Types   as AWS
 
-import qualified Fission.Config as Config
-import           Fission.Internal.UTF8
-
 import qualified Fission.IPFS.Types as IPFS
-import           Fission.IPFS.Gateway.Types
 import           Fission.IPFS.CID.Types
 import           Fission.User        as User
 
 import           Fission.Web.Server
+import           Fission.Web.Error as Web.Err
 
 type API = Capture "cid" CID
         :> PutAccepted '[PlainText, OctetStream] AWS.DomainName
 
-server
-  :: ( HasLogFunc         cfg
-     , Has IPFS.Gateway   cfg
-     , Has AWS.AccessKey  cfg
-     , Has AWS.SecretKey  cfg
-     , Has AWS.ZoneID     cfg
-     , Has AWS.DomainName cfg
-     )
+server ::
+  ( HasLogFunc         cfg
+  , Has IPFS.Gateway   cfg
+  , Has AWS.AccessKey  cfg
+  , Has AWS.SecretKey  cfg
+  , Has AWS.ZoneID     cfg
+  , Has AWS.DomainName cfg
+  )
   => User
   -> RIOServer cfg API
-server User { username } (CID hash) = do
-  gateway :: IPFS.Gateway   <- Config.get
-  domain  :: AWS.DomainName <- Config.get
-
-  let
-    baseUrl    = username <> "."<> AWS.getDomainName domain
-    dnslinkUrl = "_dnslink." <> baseUrl
-    dnslink    = "dnslink=/ipfs/" <> hash
-
-  gateway
-    |> getGateway
-    |> registerDomain Route53.Cname baseUrl
-    |> ensureContent
-
-  dnslink
-    |> wrapIn' "\""
-    |> registerDomain Route53.Txt dnslinkUrl
-    |> ensureContent
-
-  return <| AWS.DomainName baseUrl
-
-wrapIn' :: Text -> Text -> Text
-wrapIn' a b = wrapIn b a
+server User { username } cid = 
+  registerDomain username cid
+    >>= Web.Err.ensureM

--- a/library/Fission/Web/DNS.hs
+++ b/library/Fission/Web/DNS.hs
@@ -38,7 +38,7 @@ server User { username } (CID hash) = do
   domain :: AWS.DomainName <- Config.get
 
   let
-    baseUrl    = username <> AWS.getDomainName domain
+    baseUrl    = username <> "."<> AWS.getDomainName domain
     dnslinkUrl = "_dnslink." <> baseUrl
     dnslink    = "dnslink=/ipfs/" <> hash
 

--- a/library/Fission/Web/User.hs
+++ b/library/Fission/Web/User.hs
@@ -16,6 +16,8 @@ import qualified Fission.Web.User.Verify as Verify
 import qualified Fission.Web.User.Password.Reset as Reset
 import qualified Fission.Web.Auth.Types  as Auth
 
+import qualified Fission.IPFS.Types as IPFS
+
 type API = Create.API
       :<|> VerifyRoute
       :<|> ResetRoute
@@ -31,6 +33,7 @@ type ResetRoute = "reset_password"
 server
   :: ( HasLogFunc         cfg
      , MonadSelda    (RIO cfg)
+     , Has IPFS.Gateway   cfg
      , Has AWS.DomainName cfg
      , Has AWS.AccessKey  cfg
      , Has AWS.SecretKey  cfg

--- a/library/Fission/Web/User/Create.hs
+++ b/library/Fission/Web/User/Create.hs
@@ -9,27 +9,27 @@ import           Database.Selda as Selda
 import           Servant
 
 import           Fission.Prelude
-import qualified Fission.Config as Config
 
 import           Fission.Web.Server
+import           Fission.Web.Error as Web.Err
 
 import qualified Fission.User                     as User
 import qualified Fission.User.Registration.Types  as User
 
-import           Fission.AWS
 import qualified Fission.AWS.Types   as AWS
 import           Fission.AWS.Route53
 
 import           Network.AWS.Auth    as AWS
-import qualified Network.AWS.Route53 as Route53
 
-import           Fission.Internal.UTF8
+import qualified Fission.IPFS.Types as IPFS
+import           Fission.IPFS.CID.Types
 
 type API = ReqBody '[JSON] User.Registration
         :> Post '[JSON] ()
 
 server
   :: ( HasLogFunc         cfg
+     , Has IPFS.Gateway   cfg
      , Has AWS.DomainName cfg
      , Has AWS.AccessKey  cfg
      , Has AWS.SecretKey  cfg
@@ -38,29 +38,13 @@ server
      )
   => RIOServer cfg API
 server (User.Registration username password email) = do
-  domain :: AWS.DomainName <- Config.get
-
   userID <- User.create username password email
   logInfo <| "Provisioned user: " <> displayShow userID
 
-  let
-    baseUrl    = username <> AWS.getDomainName domain
-    dnsLinkUrl = "_dnslink." <> baseUrl
-    dnsLinkTxt = "dnslink=/ipfs/" <> splashCID
+  registerDomain username splashCID
+    >>= Web.Err.ensureM
 
-  "ipfs.runfission.com"
-    |> registerDomain Route53.Cname baseUrl
-    |> ensureContent
+  return  ()
 
-  dnsLinkTxt
-    |> wrapIn' "\""
-    |> registerDomain Route53.Txt dnsLinkUrl
-    |> ensureContent
-
-  return ()
-
-wrapIn' :: Text -> Text -> Text
-wrapIn' a b = wrapIn b a
-
-splashCID :: Text
-splashCID = "QmRVvvMeMEPi1zerpXYH9df3ATdzuB63R1wf3Mz5NS5HQN"
+splashCID :: CID
+splashCID = CID "QmRVvvMeMEPi1zerpXYH9df3ATdzuB63R1wf3Mz5NS5HQN"


### PR DESCRIPTION
## Problem
- gateway not in env
- `domain_name` starts with a `.`

## Solution
- create env variable
- add `.` to `domain_name` in code instead of env file
- refactor `registerDomain` function to eliminate WET code

A bit of clarification on variables: 
1) `ipfs.gateway` is our ipfs gateway (ie `ipfs.runfission.com`). This gets set as the cname value for any domain a user registers
2) `aws.domain_name` is the base domain name that we use for user's domain names (ie `fission.name`)

The issue (https://github.com/fission-suite/web-api/issues/162) was initially misframed because we were using `demo.runfission.com` as our `aws.domain_name` so both domains could be derived from the same base (`runfission.com`), meaning we didn't need two separate variables.

Closes https://github.com/fission-suite/web-api/issues/162