### PR TITLE
Remove streamly as it's unused

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -119,7 +119,6 @@ dependencies:
   - servant-swagger
   - servant-swagger-ui
   - streaming-commons
-  - streamly
   - swagger2
   - text
   - time


### PR DESCRIPTION

## Summary
Removes an unused dependency (at least Im pretty sure it is cc: @expede). This actually fixes an issue in building for windows. 
https://github.com/fission-suite/cli/pull/48

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
