### PR TITLE
Move default fission peer to env var

### DIFF
--- a/app/Fission/Environment/IPFS/Types.hs
+++ b/app/Fission/Environment/IPFS/Types.hs
@@ -5,17 +5,19 @@ import           Fission.Prelude
 import qualified Fission.IPFS.Types as IPFS
 
 data Environment = Environment
-  { url     :: !IPFS.URL     -- ^ IPFS client URL (may be remote)
-  , timeout :: !IPFS.Timeout -- ^ IPFS timeout in seconds
-  , binPath :: !IPFS.BinPath -- ^ Path to local IPFS binary
-  , gateway :: !IPFS.Gateway -- ^ Domain Name of IPFS Gateway
+  { url        :: !IPFS.URL     -- ^ IPFS client URL (may be remote)
+  , timeout    :: !IPFS.Timeout -- ^ IPFS timeout in seconds
+  , binPath    :: !IPFS.BinPath -- ^ Path to local IPFS binary
+  , gateway    :: !IPFS.Gateway -- ^ Domain Name of IPFS Gateway
+  , remotePeer :: !IPFS.Peer    -- ^ Remote Peer to connect to
   } deriving Show
 
 instance FromJSON Environment where
   parseJSON = withObject "IPFS.Environment" \obj -> do
-    timeout <- obj .:? "timeout" .!= 3600
-    binPath <- obj .:? "binPath" .!= "/usr/local/bin/ipfs"
-    gateway <- obj .:? "gateway" .!= "ipfs.runfission.com"
-    url     <- obj .:  "url" >>= parseJSON . String
+    timeout    <- obj .:? "timeout" .!= 3600
+    binPath    <- obj .:? "binPath" .!= "/usr/local/bin/ipfs"
+    gateway    <- obj .:? "gateway" .!= "ipfs.runfission.com"
+    url        <- obj .:  "url" >>= parseJSON . String
+    remotePeer <- obj .:  "remotePeer"
 
     return <| Environment {..}

--- a/app/Fission/Internal/Development.hs
+++ b/app/Fission/Internal/Development.hs
@@ -77,10 +77,11 @@ run logFunc dbPool processCtx httpManager action =
     herokuID       = Hku.ID       "HEROKU_ID"
     herokuPassword = Hku.Password "HEROKU_PASSWORD"
 
-    ipfsPath    = "/usr/local/bin/ipfs"
-    ipfsURL     = IPFS.URL <| BaseUrl Http "localhost" 5001 ""
-    ipfsTimeout = IPFS.Timeout 3600
+    ipfsPath       = "/usr/local/bin/ipfs"
+    ipfsURL        = IPFS.URL <| BaseUrl Http "localhost" 5001 ""
+    ipfsTimeout    = IPFS.Timeout 3600
     ipfsGateway    = IPFS.Gateway "ipfs.runfission.com"
+    ipfsRemotePeer = IPFS.Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"
 
     awsAccessKey  = "SOME_AWS_ACCESS_KEY"
     awsSecretKey  = "SOME_AWS_SECRET_KEY"
@@ -122,6 +123,7 @@ mkConfig dbPool processCtx httpManager logFunc = Config {..}
 
     ipfsPath       = "/usr/local/bin/ipfs"
     ipfsURL        = IPFS.URL <| BaseUrl Http "localhost" 5001 ""
+    ipfsRemotePeer = IPFS.Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"
     ipfsTimeout    = IPFS.Timeout 3600
     ipfsGateway    = IPFS.Gateway "ipfs.runfission.com"
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -44,9 +44,10 @@ main = do
     herokuID       = Hku.ID       <| encodeUtf8 (manifest |> Hku.id)
     herokuPassword = Hku.Password <| encodeUtf8 (manifest |> Hku.api |> Hku.password)
 
-    ipfsPath    = env |> ipfs |> binPath
-    ipfsURL     = env |> ipfs |> url
-    ipfsTimeout = env |> ipfs |> IPFS.timeout
+    ipfsPath       = env |> ipfs |> binPath
+    ipfsURL        = env |> ipfs |> url
+    ipfsRemotePeer = env |> ipfs |> remotePeer
+    ipfsTimeout    = env |> ipfs |> IPFS.timeout
     ipfsGateway = env |> ipfs |> gateway
 
     awsAccessKey  = accessKey

--- a/example-config/env.yaml.example
+++ b/example-config/env.yaml.example
@@ -9,6 +9,7 @@ ipfs:
   url: http://localhost:5001
   gateway: ipfs.runfission.com
   timeout: 3600
+  remotePeer: /ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw
 
 storage:
   stripe_count: 4

--- a/library/Fission/Config/Types.hs
+++ b/library/Fission/Config/Types.hs
@@ -18,6 +18,7 @@ data Config dbBackend = Config
   , httpManager    :: !HTTP.Manager
   , ipfsPath       :: !IPFS.BinPath
   , ipfsURL        :: !IPFS.URL
+  , ipfsRemotePeer :: !IPFS.Peer
   , ipfsTimeout    :: !IPFS.Timeout
   , ipfsGateway    :: !IPFS.Gateway
   , host           :: !Host
@@ -38,6 +39,7 @@ instance Show (Config dbBackend) where
     , "  httpManager    = **SOME HTTP MANAGER**"
     , "  ipfsPath       = " <> show ipfsPath
     , "  ipfsURL        = " <> show ipfsURL
+    , "  ipfsRemotePeer = " <> show ipfsRemotePeer
     , "  ipfsTimeout    = " <> show ipfsTimeout
     , "  ipfsGateway    = " <> show ipfsGateway
     , "  host           = " <> show host
@@ -70,6 +72,10 @@ instance Has IPFS.BinPath (Config db) where
 instance Has IPFS.URL (Config db) where
   hasLens = lens ipfsURL \cfg newIPFSURL ->
     cfg { ipfsURL = newIPFSURL }
+
+instance Has IPFS.Peer (Config db) where
+  hasLens = lens ipfsRemotePeer \cfg newIPFSRemotePeer ->
+    cfg { ipfsRemotePeer = newIPFSRemotePeer }
 
 instance Has IPFS.Timeout (Config db) where
   hasLens = lens ipfsTimeout \cfg newIPFSTimeout ->

--- a/library/Fission/IPFS/Peer.hs
+++ b/library/Fission/IPFS/Peer.hs
@@ -2,7 +2,6 @@ module Fission.IPFS.Peer
   ( all
   , rawList
   , connect
-  , fission
   , getExternalAddress
   ) where
 
@@ -96,12 +95,9 @@ getExternalAddress = IPFSProc.run' ["id"] >>= \case
     (ExitFailure _ , _, err) ->
       return <| Left <| UnknownErr <| UTF8.textShow err
 
-    (ExitSuccess , rawOut, _) -> do
+    (ExitSuccess , rawOut, _) ->
       rawOut
         |> decode
         |> maybe [] addresses
         |> Right . filterExternalPeers
         |> pure
-
-fission :: Peer
-fission = Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"

--- a/library/Fission/Platform/Heroku/Provision.hs
+++ b/library/Fission/Platform/Heroku/Provision.hs
@@ -17,7 +17,6 @@ import qualified Fission.User.Provision.Types       as User
 import           Fission.Security.Types
 import           Fission.User                       (User)
 import           Fission.IPFS.Types                 as IPFS
-import           Fission.IPFS.Peer (fission)
 
 data Request = Request
   { callbackUrl :: Text          -- ^ The URL which should be used to retrieve updated information about the add-on and the app which owns it.
@@ -147,7 +146,7 @@ instance ToSchema Provision where
       provisionEx = Provision
         { id      = toId 4213
         , config  = cfgEx
-        , peers  = [fission]
+        , peers  = [IPFS.Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"]
         , message = "Provisioned successfully"
         }
 

--- a/library/Fission/Web.hs
+++ b/library/Fission/Web.hs
@@ -48,6 +48,7 @@ app
      , Has IPFS.Timeout    cfg
      , Has IPFS.URL        cfg
      , Has IPFS.Gateway    cfg
+     , Has IPFS.Peer       cfg
      , Has HTTP.Manager    cfg
      , Has Web.Host        cfg
      , Has AWS.AccessKey   cfg
@@ -99,6 +100,7 @@ server
      , Has IPFS.Timeout   cfg
      , Has IPFS.URL       cfg
      , Has IPFS.Gateway   cfg
+     , Has IPFS.Peer      cfg
      , Has HTTP.Manager   cfg
      , Has Web.Host       cfg
      , Has AWS.AccessKey  cfg

--- a/library/Fission/Web/IPFS.hs
+++ b/library/Fission/Web/IPFS.hs
@@ -46,6 +46,7 @@ server :: HasLogFunc        cfg
        => MonadSelda   (RIO cfg)
        => Has HTTP.Manager  cfg
        => Has IPFS.URL      cfg
+       => Has IPFS.Peer     cfg
        => Has IPFS.BinPath  cfg
        => Has IPFS.Timeout  cfg
        => RIOServer         cfg API
@@ -67,6 +68,7 @@ authed usr = CID.allForUser usr
 public :: HasLogFunc        cfg
        => HasProcessContext cfg
        => Has IPFS.BinPath  cfg
+       => Has IPFS.Peer     cfg
        => Has IPFS.Timeout  cfg
        => RIOServer         cfg PublicAPI
 public = Peer.get

--- a/library/Fission/Web/IPFS/Peer.hs
+++ b/library/Fission/Web/IPFS/Peer.hs
@@ -6,10 +6,11 @@ module Fission.Web.IPFS.Peer
 import           Servant
 
 import           Fission.Prelude
-import           Fission.IPFS.Peer as IPFS.Peer
+import           Fission.IPFS.Peer  as IPFS.Peer
 import           Fission.Web.Server
 import qualified Fission.IPFS.Types as IPFS
 import qualified Fission.Web.Error  as Web.Err
+import qualified Fission.Config     as Config
 
 type API = Get '[JSON, PlainText, OctetStream] [IPFS.Peer]
 
@@ -17,10 +18,13 @@ type API = Get '[JSON, PlainText, OctetStream] [IPFS.Peer]
 get
   :: ( Has IPFS.BinPath  cfg
      , Has IPFS.Timeout  cfg
+     , Has IPFS.Peer  cfg
      , HasProcessContext cfg
      , HasLogFunc        cfg
      )
   => RIOServer cfg API
-get = getExternalAddress >>= \case
-  Right peers -> return (IPFS.Peer.fission : peers)
-  Left err    -> Web.Err.throw err
+get = do
+  remotePeer <- Config.get
+  getExternalAddress >>= \case
+    Right peers -> return (remotePeer : peers)
+    Left err    -> Web.Err.throw err


### PR DESCRIPTION

## Summary
Moves our s3 remote peer address to our config file


## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #146

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
* [ ] ENSURE YOU ADD `ipfs.remotePeer: /ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw` to production