### PR TITLE
Fix Swagger docs cURL generator & domain example

### DIFF
--- a/library/Fission/AWS/DomainName/Types.hs
+++ b/library/Fission/AWS/DomainName/Types.hs
@@ -1,6 +1,6 @@
 module Fission.AWS.DomainName.Types (DomainName (..)) where
 
-import           Data.Swagger (ToSchema (..))
+import           Data.Swagger
 import qualified RIO.ByteString.Lazy as Lazy
 import           Servant
 
@@ -13,8 +13,16 @@ newtype DomainName = DomainName { getDomainName :: Text }
                     , Generic
                     , Show
                     )
-  deriving anyclass ( ToSchema )
   deriving newtype  ( IsString )
+
+instance ToSchema DomainName where
+  declareNamedSchema _ =
+    mempty
+      |> example     ?~ "myawesomedomain.com"
+      |> description ?~ "A domain name"
+      |> type_       ?~ SwaggerString
+      |> NamedSchema (Just "DomainName")
+      |> pure
 
 instance FromJSON DomainName where
   parseJSON = withText "AWS.DomainName" \txt ->

--- a/library/Fission/Web.hs
+++ b/library/Fission/Web.hs
@@ -13,7 +13,6 @@ import           RIO.Process (HasProcessContext)
 
 import           Data.Has
 import           Database.Selda
-import           Data.Swagger as Swagger
 import qualified Network.HTTP.Client as HTTP
 import           Servant
 
@@ -67,7 +66,7 @@ app = do
   auth <- mkAuth
   appHost :: Web.Host <- Config.get
 
-  Swagger.Host (show appHost) Nothing
+  appHost
     |> server
     |> Auth.server api cfg
     |> serveWithContext api auth
@@ -110,11 +109,11 @@ server
      , HasLogFunc         cfg
      , MonadSelda    (RIO cfg)
      )
-  => Swagger.Host
+  => Web.Host
   -> RIOServer cfg API
-server host' = Web.Swagger.server host'
-          :<|> IPFS.server
-          :<|> const Heroku.server
-          :<|> User.server
-          :<|> pure Ping.pong
-          :<|> DNS.server
+server appHost = Web.Swagger.server appHost
+            :<|> IPFS.server
+            :<|> const Heroku.server
+            :<|> User.server
+            :<|> pure Ping.pong
+            :<|> DNS.server

--- a/library/Fission/Web.hs
+++ b/library/Fission/Web.hs
@@ -62,9 +62,9 @@ app
      )
     => RIO cfg Application
 app = do
-  cfg  <- ask
-  auth <- mkAuth
-  appHost :: Web.Host <- Config.get
+  cfg     <- ask
+  auth    <- mkAuth
+  appHost <- Config.get
 
   appHost
     |> server

--- a/library/Fission/Web/Swagger.hs
+++ b/library/Fission/Web/Swagger.hs
@@ -5,6 +5,7 @@ module Fission.Web.Swagger
 
 import           Data.Swagger
 import           Servant
+import           Servant.Client (BaseUrl (..))
 import           Servant.Swagger
 import           Servant.Swagger.UI
 import qualified Servant.Swagger.Internal.TypeLevel.API as Servant.API
@@ -16,40 +17,50 @@ import           Fission.Internal.Orphanage.MultipartForm ()
 
 import qualified Fission.Web.Routes as Web
 import           Fission.Web.Server
+import qualified Fission.Web.Types as Web
 
 type API = SwaggerSchemaUI "docs" "docs.json"
 
-server :: Host -> RIOServer cfg API
-server = hoistServer (Proxy @API) fromHandler . swaggerSchemaUIServer . docs
+server :: Web.Host -> RIOServer cfg API
+server appHost =
+  appHost
+    |> docs
+    |> swaggerSchemaUIServer
+    |> hoistServer (Proxy @API) fromHandler
 
-docs :: Host -> Swagger
-docs host' = host'
-          |> app (Proxy @Web.API)
-          |> dns
-          |> ipfs
-          |> heroku
-          |> ping
-          |> user
+docs :: Web.Host -> Swagger
+docs host' =
+  host'
+    |> app (Proxy @Web.API)
+    |> dns
+    |> ipfs
+    |> heroku
+    |> ping
+    |> user
 
-app :: HasSwagger api => Proxy api -> Host -> Swagger
-app proxy appHost = toSwagger proxy
-                 |> host               ?~ appHost
-                 |> schemes            ?~ [Https, Http]
-                 |> info . title       .~ "The Fission API"
-                 |> info . version     .~ "1.20.0"
-                 |> info . description ?~ blurb
-                 |> info . contact     ?~ fissionContact
-                 |> info . license     ?~ projectLicense
+app :: HasSwagger api => Proxy api -> Web.Host -> Swagger
+app proxy (Web.Host (BaseUrl { baseUrlHost })) =
+  proxy
+    |> toSwagger
+    |> host               ?~ Host baseUrlHost Nothing
+    |> schemes            ?~ [Https]
+    |> info . title       .~ "The Fission API"
+    |> info . version     .~ "2.0.0"
+    |> info . description ?~ blurb
+    |> info . contact     ?~ fissionContact
+    |> info . license     ?~ projectLicense
   where
-    fissionContact = mempty
-                  |> name  ?~"Team Fission"
-                  |> url   ?~ URL "https://fission.codes"
-                  |> email ?~ "support@fission.codes"
+    fissionContact =
+      mempty
+        |> name  ?~"Team Fission"
+        |> url   ?~ URL "https://fission.codes"
+        |> email ?~ "support@fission.codes"
 
-    projectLicense = "Apache 2.0"
-                  |> url ?~ URL "http://www.apache.org/licenses/LICENSE-2.0"
+    projectLicense =
+      "Apache 2.0" |> url ?~ URL "http://www.apache.org/licenses/LICENSE-2.0"
 
-    blurb = "Bootstrapped & distributed backend-as-a-service with user-controlled data"
+    blurb =
+      "Bootstrapped & distributed backend-as-a-service with user-controlled data"
 
 dns :: Swagger -> Swagger
 dns = makeDocs (Proxy @Web.DNSRoute)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-api
-version: '2.0.0'
+version: '2.0.1'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
This PR introduces a handful of Swagger doc changes.

* Focus on production version
  * Remove HTTP from scheme drop-down
  * No longer append the port (assume 443)
* Generate valid `curl` commands
  * Fix hostname (had extra quotes around it before)
  * Fix docs on domain names
  * Add example to domain 

# Sane URLs

## Before

<img width="695" alt="Screen Shot 2019-11-30 at 22 07 05" src="https://user-images.githubusercontent.com/1052016/69906067-d2868780-13bd-11ea-9561-b3c5b53e41dc.png">

## After

<img width="1225" alt="Screen Shot 2019-11-30 at 21 56 22" src="https://user-images.githubusercontent.com/1052016/69905978-50e22a00-13bc-11ea-9e31-11e8d9fa7e21.png">

# Fix Auto-generated Domain Docs

## Before

<img width="364" alt="Screen Shot 2019-11-30 at 22 06 44" src="https://user-images.githubusercontent.com/1052016/69906061-c69ac580-13bd-11ea-8a83-a1aab40491f6.png">

## After

<img width="389" alt="Screen Shot 2019-11-30 at 21 56 28" src="https://user-images.githubusercontent.com/1052016/69905977-50499380-13bc-11ea-87a5-8d36c6067c37.png">