### PR TITLE
Export set RIO verbose

### DIFF
--- a/library/Fission/App.hs
+++ b/library/Fission/App.hs
@@ -1,5 +1,5 @@
 -- | Helpers for running the Fission applications
-module Fission.App (runApp, isDebugEnabled) where
+module Fission.App (runApp, isDebugEnabled, setRioVerbose) where
 
 import System.Environment (setEnv, unsetEnv)
 import Fission.Environment (getFlagWithDefault)


### PR DESCRIPTION
## Summary
I forgot to export a key function I had wanted to use in cli to set `RIO_VERBOSE` to true