### PR TITLE
Rename awsMock to route53Mock

### DIFF
--- a/app/Fission/Environment/AWS/Types.hs
+++ b/app/Fission/Environment/AWS/Types.hs
@@ -11,26 +11,26 @@ data Environment = Environment
   , secretKey   :: !AWS.SecretKey  -- ^ Secret Key
   , zoneID      :: !AWS.ZoneID     -- ^ Hosted Zone
   , domainName  :: !AWS.DomainName -- ^ Domain Name
-  , mockEnabled :: !AWS.MockEnabled
+  , route53MockEnabled :: !AWS.Route53MockEnabled
   }
 
 instance Show Environment where
   show Environment {..} = intercalate "\n"
     [ "Environment {"
-    , "  accessKey  = HIDDEN"
-    , "  secretKey  = HIDDEN"
-    , "  zoneId     = " <> show zoneID
-    , "  domainName = " <> show domainName
-    , "  mockEnabled = " <> show mockEnabled
+    , "  accessKey          = HIDDEN"
+    , "  secretKey          = HIDDEN"
+    , "  zoneId             = " <> show zoneID
+    , "  domainName         = " <> show domainName
+    , "  route53MockEnabled = " <> show route53MockEnabled
     , "}"
     ]
 
 instance FromJSON Environment where
   parseJSON = withObject "AWS.Environment" \obj -> do
-    accessKey   <- obj .: "access_key"
-    secretKey   <- obj .: "secret_key"
-    zoneID      <- obj .: "zone_id"
-    domainName  <- obj .: "domain_name"
-    mockEnabled <- obj .:? "mock_enabled" .!= AWS.MockEnabled False
+    accessKey          <- obj .: "access_key"
+    secretKey          <- obj .: "secret_key"
+    zoneID             <- obj .: "zone_id"
+    domainName         <- obj .: "domain_name"
+    route53MockEnabled <- obj .:? "route53_mock_enabled" .!= AWS.Route53MockEnabled False
 
     return <| Environment {..}

--- a/app/Fission/Internal/Development.hs
+++ b/app/Fission/Internal/Development.hs
@@ -85,11 +85,11 @@ run logFunc dbPool processCtx httpManager action =
     ipfsGateway    = IPFS.Gateway "ipfs.runfission.com"
     ipfsRemotePeer = IPFS.Peer "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw"
 
-    awsAccessKey  = "SOME_AWS_ACCESS_KEY"
-    awsSecretKey  = "SOME_AWS_SECRET_KEY"
-    awsZoneID     = "SOME_AWS_ZONE_ID"
-    awsDomainName = "SOME_AWS_DOMAIN_NAME"
-    awsMockEnabled = AWS.MockEnabled True
+    awsAccessKey          = "SOME_AWS_ACCESS_KEY"
+    awsSecretKey          = "SOME_AWS_SECRET_KEY"
+    awsZoneID             = "SOME_AWS_ZONE_ID"
+    awsDomainName         = "SOME_AWS_DOMAIN_NAME"
+    awsRoute53MockEnabled = AWS.Route53MockEnabled True
 
 {- | Setup a complete development configuration with all pure defaults set
 
@@ -130,11 +130,11 @@ mkConfig dbPool processCtx httpManager logFunc = Config {..}
     ipfsTimeout    = IPFS.Timeout 3600
     ipfsGateway    = IPFS.Gateway "ipfs.runfission.com"
 
-    awsAccessKey  = "SOME_AWS_ACCESS_KEY"
-    awsSecretKey  = "SOME_AWS_SECRET_KEY"
-    awsZoneID     = "SOME_AWS_ZONE_ID"
-    awsDomainName = "SOME_AWS_DOMAIN_NAME"
-    awsMockEnabled = AWS.MockEnabled True
+    awsAccessKey          = "SOME_AWS_ACCESS_KEY"
+    awsSecretKey          = "SOME_AWS_SECRET_KEY"
+    awsZoneID             = "SOME_AWS_ZONE_ID"
+    awsDomainName         = "SOME_AWS_DOMAIN_NAME"
+    awsRoute53MockEnabled = AWS.Route53MockEnabled True
 
 {- | Setup a complete development configuration.
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -48,13 +48,13 @@ main = do
     ipfsURL        = env |> ipfs |> url
     ipfsRemotePeer = env |> ipfs |> remotePeer
     ipfsTimeout    = env |> ipfs |> IPFS.timeout
-    ipfsGateway = env |> ipfs |> gateway
+    ipfsGateway    = env |> ipfs |> gateway
 
-    awsAccessKey  = accessKey
-    awsSecretKey  = secretKey
-    awsZoneID     = zoneID
-    awsDomainName = domainName
-    awsMockEnabled = mockEnabled
+    awsAccessKey          = accessKey
+    awsSecretKey          = secretKey
+    awsZoneID             = zoneID
+    awsDomainName         = domainName
+    awsRoute53MockEnabled = route53MockEnabled
 
   isVerbose  <- isDebugEnabled
   logOptions <- logOptionsHandle stdout isVerbose

--- a/example-config/env.yaml.example
+++ b/example-config/env.yaml.example
@@ -19,7 +19,7 @@ storage:
     host: localhost
     database: web_api
 aws:
-  mock_enabled: true
+  route53_mock_enabled: true
   # access_key:
   # secret_key:
   # zone_id:

--- a/library/Fission/AWS/Types.hs
+++ b/library/Fission/AWS/Types.hs
@@ -2,14 +2,14 @@
 module Fission.AWS.Types
   ( DomainName (..)
   , ZoneID (..)
-  , MockEnabled (..)
+  , Route53MockEnabled (..)
   ) where
 
 import Fission.AWS.DomainName.Types
 import Fission.AWS.Zone.Types
 import Fission.Prelude
 
-newtype MockEnabled = MockEnabled Bool deriving (Show)-- newtype MockEnabled = Bool()
-instance FromJSON MockEnabled where
-  parseJSON = withBool "AWS.MockEnabled" \val ->
-    MockEnabled <$> parseJSON (Bool val)
+newtype Route53MockEnabled = Route53MockEnabled Bool deriving (Show)
+instance FromJSON Route53MockEnabled where
+  parseJSON = withBool "AWS.Route53MockEnabled" \val ->
+    Route53MockEnabled <$> parseJSON (Bool val)

--- a/library/Fission/Config/Types.hs
+++ b/library/Fission/Config/Types.hs
@@ -13,45 +13,45 @@ import qualified Fission.AWS.Types             as AWS
 
 -- | The top level 'Fission' application 'RIO' configuration
 data Config dbBackend = Config
-  { processCtx     :: !ProcessContext
-  , logFunc        :: !LogFunc
-  , httpManager    :: !HTTP.Manager
-  , ipfsPath       :: !IPFS.BinPath
-  , ipfsURL        :: !IPFS.URL
-  , ipfsRemotePeer :: !IPFS.Peer
-  , ipfsTimeout    :: !IPFS.Timeout
-  , ipfsGateway    :: !IPFS.Gateway
-  , host           :: !Host
-  , dbPool         :: !(DB.Pool dbBackend)
-  , herokuID       :: !Heroku.ID
-  , herokuPassword :: !Heroku.Password
-  , awsAccessKey   :: !AWS.AccessKey
-  , awsSecretKey   :: !AWS.SecretKey
-  , awsZoneID      :: !AWS.ZoneID
-  , awsDomainName  :: !AWS.DomainName
-  , awsMockEnabled :: !AWS.MockEnabled
+  { processCtx            :: !ProcessContext
+  , logFunc               :: !LogFunc
+  , httpManager           :: !HTTP.Manager
+  , ipfsPath              :: !IPFS.BinPath
+  , ipfsURL               :: !IPFS.URL
+  , ipfsRemotePeer        :: !IPFS.Peer
+  , ipfsTimeout           :: !IPFS.Timeout
+  , ipfsGateway           :: !IPFS.Gateway
+  , host                  :: !Host
+  , dbPool                :: !(DB.Pool dbBackend)
+  , herokuID              :: !Heroku.ID
+  , herokuPassword        :: !Heroku.Password
+  , awsAccessKey          :: !AWS.AccessKey
+  , awsSecretKey          :: !AWS.SecretKey
+  , awsZoneID             :: !AWS.ZoneID
+  , awsDomainName         :: !AWS.DomainName
+  , awsRoute53MockEnabled :: !AWS.Route53MockEnabled
   } deriving Generic
 
 instance Show (Config dbBackend) where
   show Config {..} = intercalate "\n"
     [ "Config {"
-    , "  processCtx     = **SOME PROC CONTEXT**"
-    , "  logFunc        = **SOME LOG FUNCTION**"
-    , "  httpManager    = **SOME HTTP MANAGER**"
-    , "  ipfsPath       = " <> show ipfsPath
-    , "  ipfsURL        = " <> show ipfsURL
-    , "  ipfsRemotePeer = " <> show ipfsRemotePeer
-    , "  ipfsTimeout    = " <> show ipfsTimeout
-    , "  ipfsGateway    = " <> show ipfsGateway
-    , "  host           = " <> show host
-    , "  dbPool         = " <> show dbPool
-    , "  herokuID       = " <> show herokuID
-    , "  herokuPassword = " <> show herokuPassword
-    , "  awsAccessKey   = " <> show awsAccessKey
-    , "  awsSecretKey   = HIDDEN"
-    , "  awsZoneID      = " <> show awsZoneID
-    , "  awsDomainName  = " <> show awsDomainName
-    , "  awsMockEnabled = " <> show awsMockEnabled
+    , "  processCtx            = **SOME PROC CONTEXT**"
+    , "  logFunc               = **SOME LOG FUNCTION**"
+    , "  httpManager           = **SOME HTTP MANAGER**"
+    , "  ipfsPath              = " <> show ipfsPath
+    , "  ipfsURL               = " <> show ipfsURL
+    , "  ipfsRemotePeer        = " <> show ipfsRemotePeer
+    , "  ipfsTimeout           = " <> show ipfsTimeout
+    , "  ipfsGateway           = " <> show ipfsGateway
+    , "  host                  = " <> show host
+    , "  dbPool                = " <> show dbPool
+    , "  herokuID              = " <> show herokuID
+    , "  herokuPassword        = " <> show herokuPassword
+    , "  awsAccessKey          = " <> show awsAccessKey
+    , "  awsSecretKey          = HIDDEN"
+    , "  awsZoneID             = " <> show awsZoneID
+    , "  awsDomainName         = " <> show awsDomainName
+    , "  awsRoute53MockEnabled = " <> show awsRoute53MockEnabled
     , "}"
     ]
 
@@ -115,9 +115,9 @@ instance Has AWS.DomainName (Config db) where
   hasLens = lens awsDomainName \cfg newAWSDomainName ->
     cfg { awsDomainName = newAWSDomainName }
 
-instance Has AWS.MockEnabled (Config db) where
-  hasLens = lens awsMockEnabled \cfg newAWSMockEnabled ->
-    cfg { awsMockEnabled = newAWSMockEnabled }
+instance Has AWS.Route53MockEnabled (Config db) where
+  hasLens = lens awsRoute53MockEnabled \cfg newAWSMockEnabled ->
+    cfg { awsRoute53MockEnabled = newAWSMockEnabled }
 
 instance Has Host (Config db) where
   hasLens = lens host \cfg newHost ->

--- a/library/Fission/Web.hs
+++ b/library/Fission/Web.hs
@@ -43,20 +43,20 @@ import qualified Fission.Web.Heroku            as Heroku
 type API = Web.Swagger.API :<|> Web.API
 
 app ::
-  ( MonadLocalIPFS  (RIO cfg)
-  , MonadRemoteIPFS (RIO cfg)
-  , Has IPFS.Gateway     cfg
-  , Has IPFS.Peer        cfg
-  , Has Web.Host         cfg
-  , Has AWS.AccessKey    cfg
-  , Has AWS.SecretKey    cfg
-  , Has AWS.ZoneID       cfg
-  , Has AWS.DomainName   cfg
-  , Has AWS.MockEnabled  cfg
-  , Has Heroku.ID        cfg
-  , Has Heroku.Password  cfg
-  , HasLogFunc           cfg
-  , MonadSelda      (RIO cfg)
+  ( MonadLocalIPFS         (RIO cfg)
+  , MonadRemoteIPFS        (RIO cfg)
+  , Has IPFS.Gateway            cfg
+  , Has IPFS.Peer               cfg
+  , Has Web.Host                cfg
+  , Has AWS.AccessKey           cfg
+  , Has AWS.SecretKey           cfg
+  , Has AWS.ZoneID              cfg
+  , Has AWS.DomainName          cfg
+  , Has AWS.Route53MockEnabled  cfg
+  , Has Heroku.ID               cfg
+  , Has Heroku.Password         cfg
+  , HasLogFunc                  cfg
+  , MonadSelda             (RIO cfg)
   )
   => RIO cfg Application
 app = do
@@ -93,18 +93,18 @@ mkAuth = do
 
 -- | Web handlers for the 'API'
 server ::
-  ( MonadLocalIPFS  (RIO cfg)
-  , MonadRemoteIPFS (RIO cfg)
-  , Has IPFS.Gateway     cfg
-  , Has IPFS.Peer        cfg
-  , Has Web.Host         cfg
-  , Has AWS.AccessKey    cfg
-  , Has AWS.SecretKey    cfg
-  , Has AWS.ZoneID       cfg
-  , Has AWS.DomainName   cfg
-  , Has AWS.MockEnabled  cfg
-  , HasLogFunc           cfg
-  , MonadSelda      (RIO cfg)
+  ( MonadLocalIPFS         (RIO cfg)
+  , MonadRemoteIPFS        (RIO cfg)
+  , Has IPFS.Gateway            cfg
+  , Has IPFS.Peer               cfg
+  , Has Web.Host                cfg
+  , Has AWS.AccessKey           cfg
+  , Has AWS.SecretKey           cfg
+  , Has AWS.ZoneID              cfg
+  , Has AWS.DomainName          cfg
+  , Has AWS.Route53MockEnabled  cfg
+  , HasLogFunc                  cfg
+  , MonadSelda             (RIO cfg)
   )
   => Web.Host
   -> RIOServer cfg API

--- a/library/Fission/Web/DNS.hs
+++ b/library/Fission/Web/DNS.hs
@@ -29,7 +29,7 @@ server ::
   , Has AWS.SecretKey   cfg
   , Has AWS.ZoneID      cfg
   , Has AWS.DomainName  cfg
-  , Has AWS.MockEnabled cfg
+  , Has AWS.Route53MockEnabled cfg
   )
   => User
   -> RIOServer cfg API

--- a/library/Fission/Web/User.hs
+++ b/library/Fission/Web/User.hs
@@ -38,7 +38,7 @@ server
      , Has AWS.AccessKey   cfg
      , Has AWS.SecretKey   cfg
      , Has AWS.ZoneID      cfg
-     , Has AWS.MockEnabled cfg
+     , Has AWS.Route53MockEnabled cfg
      )
   => RIOServer cfg API
 server = Create.server

--- a/library/Fission/Web/User/Create.hs
+++ b/library/Fission/Web/User/Create.hs
@@ -33,7 +33,7 @@ server
      , Has AWS.AccessKey   cfg
      , Has AWS.SecretKey   cfg
      , Has AWS.ZoneID      cfg
-     , Has AWS.MockEnabled cfg
+     , Has AWS.Route53MockEnabled cfg
      , MonadSelda     (RIO cfg)
      )
   => RIOServer cfg API


### PR DESCRIPTION
## Summary
Renames `awsMock` to `route53Mock` and addresses some missed comments from @dholms in this PR: https://github.com/fission-suite/web-api/pull/225

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
