### PR TITLE
Improve IPFS Error message for our API consumers

### DIFF
--- a/library/Fission/Web/Error.hs
+++ b/library/Fission/Web/Error.hs
@@ -81,6 +81,7 @@ instance ToServerError Add.Error where
     Add.UnknownAddErr    _ -> err502 { errBody = "Unknown IPFS error" }
     Add.RecursiveAddErr  _ -> err502 { errBody = "Error while adding directory" }
     Add.UnexpectedOutput _ -> err502 { errBody = "Unexpected IPFS result" }
+    Add.IPFSDaemonErr  msg -> err502 { errBody = "IPFS Daemon Error: " <> UTF8.textToLazyBS msg}
 
 instance ToServerError Peer.Error where
   toServerError = \case

--- a/library/Fission/Web/Heroku/Deprovision.hs
+++ b/library/Fission/Web/Heroku/Deprovision.hs
@@ -27,6 +27,7 @@ destroy ::
   , MonadThrow      m
   , MonadRemoteIPFS m
   , MonadLogger     m
+  , MonadReader cfg m
   )
   => ServerT API m
 destroy uuid' = do

--- a/library/Fission/Web/IPFS.hs
+++ b/library/Fission/Web/IPFS.hs
@@ -60,6 +60,7 @@ authed ::
   , MonadLogger     m
   , MonadThrow      m
   , MonadTime       m
+  , MonadReader cfg m
   )
   => ServerT AuthedAPI m
 authed usr = CID.allForUser usr

--- a/library/Fission/Web/IPFS/DAG.hs
+++ b/library/Fission/Web/IPFS/DAG.hs
@@ -29,6 +29,7 @@ put ::
   , MonadLogger     m
   , MonadThrow      m
   , MonadTime       m
+  , MonadReader cfg m
   )
   => Entity User
   -> ServerT API m

--- a/library/Fission/Web/IPFS/Pin.hs
+++ b/library/Fission/Web/IPFS/Pin.hs
@@ -33,6 +33,7 @@ server ::
   , MonadThrow      m
   , MonadTime       m
   , MonadDB         m
+  , MonadReader cfg m
   )
   => Entity User
   -> ServerT API m
@@ -44,6 +45,7 @@ pin ::
   , MonadThrow      m
   , MonadTime       m
   , MonadDB         m
+  , MonadReader cfg m
   )
   => UserId
   -> ServerT PinAPI m
@@ -58,6 +60,7 @@ unpin ::
   , MonadLogger     m
   , MonadThrow      m
   , MonadDB         m
+  , MonadReader cfg m
   )
   => UserId
   -> ServerT UnpinAPI m

--- a/library/Fission/Web/IPFS/Upload.hs
+++ b/library/Fission/Web/IPFS/Upload.hs
@@ -22,6 +22,7 @@ add ::
   , MonadThrow      m
   , MonadTime       m
   , MonadDB         m
+  , MonadReader cfg m
   )
   => Entity User
   -> ServerT API m

--- a/library/Fission/Web/IPFS/Upload/Multipart.hs
+++ b/library/Fission/Web/IPFS/Upload/Multipart.hs
@@ -46,6 +46,7 @@ add ::
   , MonadLogger     m
   , MonadTime       m
   , MonadThrow      m
+  , MonadReader cfg m
   )
   => Entity User
   -> ServerT API m
@@ -58,6 +59,7 @@ textAdd ::
   , MonadTime       m
   , MonadLogger     m
   , MonadThrow      m
+  , MonadReader cfg m
   )
   => UserId
   -> ServerT TextAPI m
@@ -73,6 +75,7 @@ jsonAdd ::
   , MonadLogger     m
   , MonadTime       m
   , MonadThrow      m
+  , MonadReader cfg m
   )
   => UserId
   -> ServerT JSONAPI m
@@ -85,6 +88,7 @@ run ::
   , MonadLocalIPFS  m
   , MonadRemoteIPFS m
   , MonadThrow      m
+  , MonadReader cfg m
   )
   => UserId
   -> MultipartData Mem

--- a/library/Fission/Web/IPFS/Upload/Simple.hs
+++ b/library/Fission/Web/IPFS/Upload/Simple.hs
@@ -28,6 +28,7 @@ add ::
   , MonadThrow      m
   , MonadTime       m
   , MonadDB         m
+  , MonadReader cfg m
   )
   => Entity User
   -> ServerT API m

--- a/stack.yaml
+++ b/stack.yaml
@@ -51,7 +51,7 @@ extra-deps:
 - tasty-rerun-1.1.14
 - text-time-0.2.0
 - git: https://github.com/fission-suite/ipfs-haskell.git
-  commit: 259180765aac6f543980af16c4ed14d8e9dc4bc6
+  commit: 8ff8562c204cdcf2c63b5996439358f44675238f
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -51,7 +51,7 @@ extra-deps:
 - tasty-rerun-1.1.14
 - text-time-0.2.0
 - git: https://github.com/fission-suite/ipfs-haskell.git
-  commit: 648d6952a8857b6ecb59a3f88861b85ea812a552
+  commit: 259180765aac6f543980af16c4ed14d8e9dc4bc6
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -51,7 +51,7 @@ extra-deps:
 - tasty-rerun-1.1.14
 - text-time-0.2.0
 - git: https://github.com/fission-suite/ipfs-haskell.git
-  commit: 8ff8562c204cdcf2c63b5996439358f44675238f
+  commit: c34151de90b76e16c9725ebc168489396de01948
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -90,18 +90,18 @@ packages:
     hackage: text-time-0.2.0
 - completed:
     cabal-file:
-      size: 5077
-      sha256: b51507ea6cd5fa9fc76dbd74411112767bc48289657bbd25b2c79a9ab07d2661
+      size: 5203
+      sha256: cdf0bc88eedf8a10dd14e88bc8d19397abd2bc0f031f1ccb702446e7dfbe86dc
     name: ipfs
     version: 1.0.0
     git: https://github.com/fission-suite/ipfs-haskell.git
     pantry-tree:
-      size: 4662
-      sha256: a48a3364cb994dfea6c700a261baaf837c006458c876de067893213ef2ac1547
-    commit: 8ff8562c204cdcf2c63b5996439358f44675238f
+      size: 4839
+      sha256: c892843cbcb59ef7ceeb9106cbe248cca2e4b370757af362870562310b2a16f0
+    commit: c34151de90b76e16c9725ebc168489396de01948
   original:
     git: https://github.com/fission-suite/ipfs-haskell.git
-    commit: 8ff8562c204cdcf2c63b5996439358f44675238f
+    commit: c34151de90b76e16c9725ebc168489396de01948
 snapshots:
 - completed:
     size: 524799

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -90,18 +90,18 @@ packages:
     hackage: text-time-0.2.0
 - completed:
     cabal-file:
-      size: 5113
-      sha256: 41372127336bbe1c4af867f02ef99bd3e789d571e5ed9080d87ff4f208b92dbe
+      size: 5077
+      sha256: b51507ea6cd5fa9fc76dbd74411112767bc48289657bbd25b2c79a9ab07d2661
     name: ipfs
     version: 1.0.0
     git: https://github.com/fission-suite/ipfs-haskell.git
     pantry-tree:
-      size: 4757
-      sha256: 06910ebe986654afa5837f9f3dfb95be802564121e9fb9a7cf049efe5ef66a6b
-    commit: 648d6952a8857b6ecb59a3f88861b85ea812a552
+      size: 4662
+      sha256: c1cae2e3029cef0245f8a3f96f444bd23d7a4db0855e09b84597f8ef0ddc12fb
+    commit: 259180765aac6f543980af16c4ed14d8e9dc4bc6
   original:
     git: https://github.com/fission-suite/ipfs-haskell.git
-    commit: 648d6952a8857b6ecb59a3f88861b85ea812a552
+    commit: 259180765aac6f543980af16c4ed14d8e9dc4bc6
 snapshots:
 - completed:
     size: 524799

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -97,11 +97,11 @@ packages:
     git: https://github.com/fission-suite/ipfs-haskell.git
     pantry-tree:
       size: 4662
-      sha256: c1cae2e3029cef0245f8a3f96f444bd23d7a4db0855e09b84597f8ef0ddc12fb
-    commit: 259180765aac6f543980af16c4ed14d8e9dc4bc6
+      sha256: a48a3364cb994dfea6c700a261baaf837c006458c876de067893213ef2ac1547
+    commit: 8ff8562c204cdcf2c63b5996439358f44675238f
   original:
     git: https://github.com/fission-suite/ipfs-haskell.git
-    commit: 259180765aac6f543980af16c4ed14d8e9dc4bc6
+    commit: 8ff8562c204cdcf2c63b5996439358f44675238f
 snapshots:
 - completed:
     size: 524799


### PR DESCRIPTION
##  Summary
![image](https://user-images.githubusercontent.com/1325608/70840181-cf33c880-1dcd-11ea-8c88-ca34318e2388.png)
In cases where we have a user readable error message from IPFS we should return it to the user so that they can debug appropriately.

_Mostly this was a fun exercise learning more Haskell_

related: https://github.com/fission-suite/ipfs-haskell/pull/9
## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
