### PR TITLE
Update Register to throw a 409 on unique conflict

### DIFF
--- a/library/Fission/User/Mutation.hs
+++ b/library/Fission/User/Mutation.hs
@@ -53,16 +53,16 @@ create username password email herokuAddOnId now =
       return (Left err)
 
     Right secretDigest -> do
-      let newUserRecord = User {
-          userUsername      = username
-        , userEmail         = email
-        , userRole          = Regular
-        , userActive        = True
-        , userHerokuAddOnId = herokuAddOnId
-        , userSecretDigest  = secretDigest
-        , userInsertedAt    = now
-        , userModifiedAt    = now
-        }
+      let newUserRecord = User
+            { userUsername      = username
+            , userEmail         = email
+            , userRole          = Regular
+            , userActive        = True
+            , userHerokuAddOnId = herokuAddOnId
+            , userSecretDigest  = secretDigest
+            , userInsertedAt    = now
+            , userModifiedAt    = now
+            }
 
       insertUnique newUserRecord >>= \case
         Just userID ->

--- a/library/Fission/User/Mutation/Error.hs
+++ b/library/Fission/User/Mutation/Error.hs
@@ -22,7 +22,3 @@ instance Display Create where
 instance ToServerError Create where
   toServerError FailedDigest = err500 { errBody = "Could not create password digest" }
   toServerError AlreadyExists = err409 { errBody = "The username or email already exists in our system" }
-
--- instance Display AlreadyExists where
-
--- instance ToServerError AlreadyExists where

--- a/library/Fission/User/Mutation/Error.hs
+++ b/library/Fission/User/Mutation/Error.hs
@@ -4,6 +4,7 @@ import Servant.Server
 
 import Fission.Prelude
 import Fission.Web.Error
+import qualified Fission.Internal.UTF8 as UTF8
 
 data Create = FailedDigest
             | AlreadyExists
@@ -20,5 +21,5 @@ instance Display Create where
   display AlreadyExists = "The username or email already exists in our system"
 
 instance ToServerError Create where
-  toServerError FailedDigest = err500 { errBody = "Could not create password digest" }
-  toServerError AlreadyExists = err409 { errBody = "The username or email already exists in our system" }
+  toServerError FailedDigest = err500 { errBody = UTF8.showLazyBS <| FailedDigest }
+  toServerError AlreadyExists = err409 { errBody = UTF8.showLazyBS <| AlreadyExists }

--- a/library/Fission/User/Mutation/Error.hs
+++ b/library/Fission/User/Mutation/Error.hs
@@ -21,5 +21,5 @@ instance Display Create where
   display AlreadyExists = "The username or email already exists in our system"
 
 instance ToServerError Create where
-  toServerError FailedDigest = err500 { errBody = UTF8.showLazyBS <| FailedDigest }
-  toServerError AlreadyExists = err409 { errBody = UTF8.showLazyBS <| AlreadyExists }
+  toServerError FailedDigest = err500 { errBody = UTF8.showLazyBS FailedDigest }
+  toServerError AlreadyExists = err409 { errBody = UTF8.showLazyBS AlreadyExists }

--- a/library/Fission/User/Mutation/Error.hs
+++ b/library/Fission/User/Mutation/Error.hs
@@ -6,6 +6,8 @@ import Fission.Prelude
 import Fission.Web.Error
 
 data Create = FailedDigest
+            | AlreadyExists
+
   deriving ( Exception
            , Eq
            , Generic
@@ -15,6 +17,12 @@ data Create = FailedDigest
 
 instance Display Create where
   display FailedDigest = "Could not create password digest"
+  display AlreadyExists = "The username or email already exists in our system"
 
 instance ToServerError Create where
   toServerError FailedDigest = err500 { errBody = "Could not create password digest" }
+  toServerError AlreadyExists = err409 { errBody = "The username or email already exists in our system" }
+
+-- instance Display AlreadyExists where
+
+-- instance ToServerError AlreadyExists where

--- a/library/Fission/Web/User/Create.hs
+++ b/library/Fission/Web/User/Create.hs
@@ -37,8 +37,13 @@ server
      )
   => ServerT API m
 server (User.Registration username password email) = do
-  void . runDBNow <| User.create username password email Nothing
-  void . Web.Err.ensureM =<< registerDomain username splashCID
+  createResponse <- runDBNow <| User.create username password email Nothing
+  case createResponse of
+    Left err -> Web.Err.throw err
+    Right _userId ->
+      void . Web.Err.ensureM =<< registerDomain username splashCID
+  -- void . Web.Err.ensureM =<< (runDBNow <| User.create username password email Nothing)
+  -- void . Web.Err.ensureM =<< registerDomain username splashCID
 
 splashCID :: CID
 splashCID = CID "QmRVvvMeMEPi1zerpXYH9df3ATdzuB63R1wf3Mz5NS5HQN"

--- a/library/Fission/Web/User/Create.hs
+++ b/library/Fission/Web/User/Create.hs
@@ -38,8 +38,8 @@ server
   => ServerT API m
 server (User.Registration username password email) = do
   createResponse <- runDBNow <| User.create username password email Nothing
-  void . Web.Err.ensure <| createResponse
-  void . Web.Err.ensureM =<< registerDomain username splashCID
+  void <| Web.Err.ensure <| createResponse
+  void <| Web.Err.ensureM =<< registerDomain username splashCID
 
 splashCID :: CID
 splashCID = CID "QmRVvvMeMEPi1zerpXYH9df3ATdzuB63R1wf3Mz5NS5HQN"

--- a/library/Fission/Web/User/Create.hs
+++ b/library/Fission/Web/User/Create.hs
@@ -38,12 +38,8 @@ server
   => ServerT API m
 server (User.Registration username password email) = do
   createResponse <- runDBNow <| User.create username password email Nothing
-  case createResponse of
-    Left err -> Web.Err.throw err
-    Right _userId ->
-      void . Web.Err.ensureM =<< registerDomain username splashCID
-  -- void . Web.Err.ensureM =<< (runDBNow <| User.create username password email Nothing)
-  -- void . Web.Err.ensureM =<< registerDomain username splashCID
+  void . Web.Err.ensure <| createResponse
+  void . Web.Err.ensureM =<< registerDomain username splashCID
 
 splashCID :: CID
 splashCID = CID "QmRVvvMeMEPi1zerpXYH9df3ATdzuB63R1wf3Mz5NS5HQN"


### PR DESCRIPTION


## Summary
Currently we throw a 500 if a users attempts to sign up with the same email / username. 
This is incorrect and we should throw a 409.



## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
