### PR TITLE
Make email required for register

### DIFF
--- a/library/Fission/User/Registration/Types.hs
+++ b/library/Fission/User/Registration/Types.hs
@@ -7,21 +7,21 @@ import Fission.Prelude
 data Registration = Registration
   { username :: !Text
   , password :: !Text
-  , email    :: !(Maybe Text)
+  , email    :: !Text
   }
 
 instance ToJSON Registration where
-  toJSON (Registration username' password' maybeEmail) =
+  toJSON (Registration username' password' email') =
     Object [ ("username", String username')
            , ("password", String password')
-           , ("email", maybe Null String maybeEmail)
+           , ("email", String email')
            ]
 
 instance FromJSON Registration where
   parseJSON = withObject "Registration" \obj -> do
     username <- obj .:  "username"
     password <- obj .:  "password"
-    email    <- obj .:? "email"
+    email    <- obj .: "email"
 
     return <| Registration {..}
 
@@ -44,7 +44,7 @@ instance ToSchema Registration where
       |> example ?~ toJSON Registration
            { username = "username"
            , password = "password123!"
-           , email    = Just "alice@example.com"
+           , email    = "alice@example.com"
            }
       |> NamedSchema (Just "Registration")
       |> pure

--- a/library/Fission/User/Registration/Types.hs
+++ b/library/Fission/User/Registration/Types.hs
@@ -11,10 +11,10 @@ data Registration = Registration
   }
 
 instance ToJSON Registration where
-  toJSON (Registration username' password' email') =
-    Object [ ("username", String username')
-           , ("password", String password')
-           , ("email", String email')
+  toJSON Registration { username, password, email } =
+    Object [ ("username", String username)
+           , ("password", String password)
+           , ("email", String email)
            ]
 
 instance FromJSON Registration where

--- a/library/Fission/Web/User/Create.hs
+++ b/library/Fission/Web/User/Create.hs
@@ -37,7 +37,7 @@ server
      )
   => ServerT API m
 server (User.Registration username password email) = do
-  createResponse <- runDBNow <| User.create username password email Nothing
+  createResponse <- runDBNow <| User.create username password (Just email) Nothing
   void <| Web.Err.ensure <| createResponse
   void <| Web.Err.ensureM =<< registerDomain username splashCID
 


### PR DESCRIPTION



## Summary
Ensure email is required only for users who sign up via the register api. Heroku still does not require an email

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
