### PR TITLE
Request Body Inspection Middleware

### DIFF
--- a/library/Fission/Web/Middleware/AuthBody.hs
+++ b/library/Fission/Web/Middleware/AuthBody.hs
@@ -1,0 +1,39 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
+module Fission.Web.Middleware.AuthBody (foo) where
+
+import Fission.Prelude
+
+import Network.Wai (Middleware, strictRequestBody)
+import Network.Wai.Internal
+
+import qualified Data.ByteString.Lazy       as Lazy
+
+import qualified Data.Vault.Lazy as Vault
+
+-- type Middleware = Application -> Application
+-- type Application =
+--    Request -> (Response -> IO ResponseReceived) -> IO ResponseReceived
+
+-- how to generate a unique vault key outside this function:
+-- `vaultKey <- newKey`
+
+foo :: Vault.Key Text -> Middleware
+foo vaultKey app req sendResponse = do
+  lazyBody <- strictRequestBody req
+
+  let
+    oldVault      = vault req
+    body          = Lazy.toStrict lazyBody
+    hash          = undefined -- TODO hash the body
+    vaultWithHash = Vault.insert vaultKey hash oldVault
+
+  ioBody <- newIORef body
+
+  let
+    newReq = req
+      { requestBody = atomicModifyIORef ioBody \x -> (mempty, x)
+      , vault       = vaultWithHash
+      }
+
+  app newReq sendResponse

--- a/package.yaml
+++ b/package.yaml
@@ -140,6 +140,7 @@ dependencies:
   - warp
   - warp-tls
   - word8
+  - vault
   - vector
   - yaml
 


### PR DESCRIPTION
@dholms and I discussed what to do about the fact that reading the request body from the buffer is destructive. It makes sense that it is this way (incoming files may be very large, so not duplicating them can be critical), but is also deeply annoying.

We probably want to additionally create middleware that checks the size of an incoming file, to protect against DoS attacks. The downsides of maintaining a file uploader 😛 