### PR TITLE
Update Heroku provision to throw 409 on unique conflict

### DIFF
--- a/library/Fission/User/Mutation.hs
+++ b/library/Fission/User/Mutation.hs
@@ -29,14 +29,18 @@ createWithHeroku ::
   -> Text
   -> m (Either Error.Create UserId)
 createWithHeroku herokuUUID herokuRegion username password = runDBNow \now -> do
-  addOnId <- insert HerokuAddOn
-    { herokuAddOnUuid       = herokuUUID
-    , herokuAddOnRegion     = Just herokuRegion
-    , herokuAddOnInsertedAt = now
-    , herokuAddOnModifiedAt = now
-    }
+  let herokuAddOnRecord = HerokuAddOn
+        { herokuAddOnUuid       = herokuUUID
+        , herokuAddOnRegion     = Just herokuRegion
+        , herokuAddOnInsertedAt = now
+        , herokuAddOnModifiedAt = now
+        }
+  insertUnique herokuAddOnRecord >>= \case
+    Just addOnId ->
+      create username password Nothing (Just addOnId) now
 
-  create username password Nothing (Just addOnId) now
+    Nothing ->
+      return (Left Error.AlreadyExists)
 
 -- | Create a new, timestamped entry with optional heroku add-on
 create ::


### PR DESCRIPTION
## Summary
Update the Heroku Provision endpoint to throw a 409 AlreadyExists when a unique constraint error is thrown.
<img width="683" alt="image" src="https://user-images.githubusercontent.com/1325608/71296140-d31a9a00-233b-11ea-9ef6-d0fa7c93e245.png">


## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
