### PR TITLE
Bump ipfs-haskell to 1.0.1

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -60,6 +60,7 @@ default-extensions:
   - NamedFieldPuns
   - NoImplicitPrelude
   - NoMonomorphismRestriction
+  - NumericUnderscores
   - OverloadedStrings
   - OverloadedLabels
   - OverloadedLists

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,11 +47,10 @@ extra-deps:
 - happy-1.19.10
 - http-client-0.5.14 # Peer dependency of amazonka
 - ip-1.5.1
+- ipfs-1.0.1
 - raven-haskell-0.1.2.1
 - tasty-rerun-1.1.14
 - text-time-0.2.0
-- git: https://github.com/fission-suite/ipfs-haskell.git
-  commit: c34151de90b76e16c9725ebc168489396de01948
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -68,6 +68,13 @@ packages:
   original:
     hackage: ip-1.5.1
 - completed:
+    hackage: ipfs-1.0.1@sha256:2230e2a781b6dfb66f054ae384527e85031ed401deb70fca3db7b7e22ecaaceb,5363
+    pantry-tree:
+      size: 3558
+      sha256: f01edc360223143d3a861ef2787840c0672371807df84e8164c632791f0c5f02
+  original:
+    hackage: ipfs-1.0.1
+- completed:
     hackage: raven-haskell-0.1.2.1@sha256:59ab0300183a599650ed5761e3e984ff2934afe1ce6d924d1064876cac90275d,1255
     pantry-tree:
       size: 632
@@ -88,20 +95,6 @@ packages:
       sha256: 086572dbcc5663ab43f658634dcb3b08cc595690fba0a92387eeb7aa72651d6f
   original:
     hackage: text-time-0.2.0
-- completed:
-    cabal-file:
-      size: 5203
-      sha256: cdf0bc88eedf8a10dd14e88bc8d19397abd2bc0f031f1ccb702446e7dfbe86dc
-    name: ipfs
-    version: 1.0.0
-    git: https://github.com/fission-suite/ipfs-haskell.git
-    pantry-tree:
-      size: 4839
-      sha256: c892843cbcb59ef7ceeb9106cbe248cca2e4b370757af362870562310b2a16f0
-    commit: c34151de90b76e16c9725ebc168489396de01948
-  original:
-    git: https://github.com/fission-suite/ipfs-haskell.git
-    commit: c34151de90b76e16c9725ebc168489396de01948
 snapshots:
 - completed:
     size: 524799


### PR DESCRIPTION
Switch to using the Hackage version of `ipfs-haskell`, and bump to the most recent version