### PR TITLE
Hotfix 2.0.1

### DIFF
--- a/library/Fission/Models.hs
+++ b/library/Fission/Models.hs
@@ -61,7 +61,7 @@ User
   role          Role
   active        Bool
 
-  dataRoot      CID           default=Qmc5m94Gu7z62RC8waSKkZUrCCBJPyHbkpmGzEePxy2oXJ
+  dataRoot      CID
 
   herokuAddOnId HerokuAddOnId Maybe
   secretDigest  SecretDigest  Maybe
@@ -70,7 +70,7 @@ User
   modifiedAt    UTCTime
 
   UniqueUsername username
-  UniqueEmail    email !force
+  -- UniqueEmail    email !force
 
   deriving Show Eq
 

--- a/library/Fission/Models.hs
+++ b/library/Fission/Models.hs
@@ -61,7 +61,7 @@ User
   role          Role
   active        Bool
 
-  dataRoot      CID
+  dataRoot      CID           default=Qmc5m94Gu7z62RC8waSKkZUrCCBJPyHbkpmGzEePxy2oXJ
 
   herokuAddOnId HerokuAddOnId Maybe
   secretDigest  SecretDigest  Maybe

--- a/library/Fission/Types.hs
+++ b/library/Fission/Types.hs
@@ -26,8 +26,6 @@ import           Fission.Config.Types
 import           Fission.AWS
 import           Fission.AWS.Types as AWS
 
-import           Fission.Internal.UTF8
-
 import           Fission.IPFS.DNSLink as DNSLink
 import           Fission.IPFS.Linked
 
@@ -156,10 +154,8 @@ instance MonadDNSLink Fission where
         return (Left err)
 
       Right _ ->
-        "\""
-          |> wrapIn dnsLink
-          |> update Txt dnsLinkURL
-          |> fmap \_ -> Right baseURL
+        update Txt dnsLinkURL ("\"" <> dnsLink <> "\"")
+          <&> \_ -> Right baseURL
 
   setBase subdomain cid = do
     domain <- asks baseAppDomainName

--- a/library/Fission/Web/User/Create.hs
+++ b/library/Fission/Web/User/Create.hs
@@ -14,7 +14,7 @@ import qualified Fission.User as User
 import           Fission.User.DID.Types
 
 type API
-  =  Summary "Register a new user"
+  =  Summary "Register a new user (with user-controlled DID)"
   :> ReqBody    '[JSON] User.Registration
   :> PutCreated '[JSON] NoContent
 

--- a/library/Fission/Web/User/Create.hs
+++ b/library/Fission/Web/User/Create.hs
@@ -14,7 +14,7 @@ import qualified Fission.User as User
 import           Fission.User.DID.Types
 
 type API
-  =  Summary "Register a new user (with user-controlled DID)"
+  =  Summary "Register a new user (must auth with user-controlled DID)"
   :> ReqBody    '[JSON] User.Registration
   :> PutCreated '[JSON] NoContent
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission-web-api
-version: '2.2.0'
+version: '2.2.1'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
Post mortem:
* Upgrade script was restarting the wrong port [FIXED IN SCRIPT]
* DB was enforcing unique emails [WAITING ON DOMAINS TO DE-DUP USERS]
* Route53 API is now pickier about double quotes (maybe a newer API when we upgraded libs?). Switched quotes in code.
* A staging server wouldn't be the worst idea. We've probably hit that point